### PR TITLE
Connecting Frontend to Backend API

### DIFF
--- a/PennCourses/settings/dev.py
+++ b/PennCourses/settings/dev.py
@@ -10,7 +10,7 @@ This is the app that you want to run locally. While all Penn Courses apps run of
 they operate with different URL schemes since they have different APIs. The app value should correspond to a file
 in PennCourses/urls/. `pca` and `pcp` are two examples.
 '''
-SWITCHBOARD_TEST_APP = 'api'
+SWITCHBOARD_TEST_APP = 'pcp'
 
 DATABASES = {
     'default': {

--- a/PennCourses/urls/base.py
+++ b/PennCourses/urls/base.py
@@ -17,22 +17,16 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from rest_framework.documentation import include_docs_urls
 
-from courses.views import index
+from rest_framework.documentation import include_docs_urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('documentation/', include_docs_urls(title='API Docs')),
-    path('', index),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [
         path('__debug__/', include(debug_toolbar.urls)),
-
-        # For django versions before 2.0:
-        # url(r'^__debug__/', include(debug_toolbar.urls)),
-
     ] + urlpatterns

--- a/PennCourses/urls/pcp.py
+++ b/PennCourses/urls/pcp.py
@@ -1,5 +1,5 @@
 from .base import *
 
 urlpatterns = [
-    path('courses/', include('courses.urls')),
+    path('registrar/', include('courses.urls')),
 ] + urlpatterns

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -81,7 +81,7 @@ class CourseIdField(serializers.RelatedField):
 
 
 class CourseListSerializer(serializers.ModelSerializer):
-    course_id = serializers.ReadOnlyField()
+    id = serializers.ReadOnlyField(source='course_id')
 
     @staticmethod
     def setup_eager_loading(queryset):
@@ -92,7 +92,7 @@ class CourseListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Course
         fields = [
-            'course_id',
+            'id',
             'title',
             'description',
             'semester',
@@ -116,7 +116,7 @@ class CourseDetailSerializer(CourseListSerializer):
     class Meta:
         model = Course
         fields = [
-            'course_id',
+            'id',
             'title',
             'description',
             'semester',

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -30,7 +30,7 @@ class SectionIdField(serializers.RelatedField):
 
 
 class SectionSerializer(serializers.ModelSerializer):
-    section_id = serializers.ReadOnlyField(source='normalized')
+    id = serializers.ReadOnlyField(source='normalized')
     semester = serializers.SerializerMethodField()
     meetings = MeetingSerializer(many=True)
 
@@ -48,7 +48,7 @@ class SectionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Section
         fields = [
-            'section_id',
+            'id',
             'status',
             'activity',
             'credits',
@@ -63,7 +63,7 @@ class SectionDetailSerializer(SectionSerializer):
     class Meta:
         model = Section
         fields = [
-            'section_id',
+            'id',
             'status',
             'activity',
             'credits',

--- a/courses/views.py
+++ b/courses/views.py
@@ -21,7 +21,7 @@ class TypedSearchBackend(filters.SearchFilter):
 
     @staticmethod
     def get_search_type(request):
-        return request.GET.get('type')
+        return request.GET.get('type', 'auto')
 
     def get_search_terms(self, request):
         search_type = self.get_search_type(request)

--- a/frontend/plan/src/actions/index.js
+++ b/frontend/plan/src/actions/index.js
@@ -162,26 +162,14 @@ const preprocessCourseSearchData = (searchData) => {
     return data;
 };
 
-const preprocessSectionSearchData = (searchData) => {
-    const data = searchData;
-    data.param = searchData.param.toLowerCase().replace(/\s/, "");
-    data.resultType = "sectSearch";
-    return data;
-};
 
 const SEMESTER = "2019C";
 
-function buildCourseSearchUrl(initSearchData) {
-    let searchData = initSearchData;
-    searchData = preprocessCourseSearchData(searchData);
-    // console.log(url);
+function buildCourseSearchUrl(searchData) {
     return `/registrar/${SEMESTER}/courses/?search=${searchData.param}`;
 }
 
-function buildSectionInfoSearchUrl(initCourseData) {
-    let searchData = initCourseData;
-    searchData = preprocessSectionSearchData(searchData);
-    // console.log(url);
+function buildSectionInfoSearchUrl(searchData) {
     return `/registrar/${SEMESTER}/courses/${searchData.param}`;
 }
 

--- a/frontend/plan/src/actions/index.js
+++ b/frontend/plan/src/actions/index.js
@@ -169,68 +169,21 @@ const preprocessSectionSearchData = (searchData) => {
     return data;
 };
 
+const SEMESTER = "2019C";
 
 function buildCourseSearchUrl(initSearchData) {
     let searchData = initSearchData;
     searchData = preprocessCourseSearchData(searchData);
-    const url = `/Search?searchType=${searchData.searchType}&resultType=${searchData.resultType}&searchParam=${searchData.param}`;
     // console.log(url);
-    return url;
+    return `/registrar/${SEMESTER}/courses/?search=${searchData.param}`;
 }
 
 function buildSectionInfoSearchUrl(initCourseData) {
     let searchData = initCourseData;
     searchData = preprocessSectionSearchData(searchData);
-    const url = `/Search?searchType=${searchData.searchType}&resultType=${searchData.resultType}&searchParam=${searchData.param}`;
     // console.log(url);
-    return url;
+    return `/registrar/${SEMESTER}/courses/${searchData.param}`;
 }
-
-const processSearchData = searchData => searchData.map((item) => {
-    const newItem = item;
-    const qFrac = newItem.revs.cQ / 4;
-    const dFrac = newItem.revs.cD / 4;
-    const iFrac = newItem.revs.cI / 4;
-    newItem.pcrQShade = (qFrac ** 3) * 2; // This is the opacity of the PCR block
-    newItem.pcrDShade = (dFrac ** 3) * 2;
-    newItem.pcrIShade = (iFrac ** 3) * 2;
-    if (qFrac < 0.50) {
-        newItem.pcrQColor = "black";
-    } else {
-        newItem.pcrQColor = "white";
-    } // It's hard to see white text on a light background
-    if (dFrac < 0.50) {
-        newItem.pcrDColor = "black";
-    } else {
-        newItem.pcrDColor = "white";
-    }
-    if (iFrac < 0.50) {
-        newItem.pcrIColor = "black";
-    } else {
-        newItem.pcrIColor = "white";
-    }
-    // This is my way of calculating if a class is "good and easy."
-    // R > 1 means good and easy, < 1 means bad and hard
-    newItem.revs.QDratio = newItem.revs.cQ - newItem.revs.cD;
-
-    // Cleanup to keep incomplete data on the bottom;
-    if (Number.isNaN(item.revs.QDratio) || !Number.isFinite(item.revs.QDratio)) {
-        newItem.revs.QDratio = 0;
-    }
-    // the rating as a string - let's us make the actual rating
-    // something else and still show the correct number
-    newItem.revs.cQT = newItem.revs.cQ.toFixed(2);
-    if (newItem.revs.cQ === 0) {
-        newItem.revs.cQT = "";
-    }
-    newItem.revs.cDT = newItem.revs.cD.toFixed(2);
-    if (newItem.revs.cD === 0) {
-        newItem.revs.cDT = "";
-        newItem.revs.QDratio = -100;
-        newItem.revs.cD = 100;
-    }
-    return newItem;
-});
 
 
 export function courseSearchError(error) {
@@ -252,7 +205,7 @@ export function fetchCourseSearch(searchData) {
         dispatch(requestSearch(searchData));
         return fetch(buildCourseSearchUrl(searchData)).then(
             response => response.json().then(
-                json => dispatch(updateSearch(processSearchData(json))),
+                json => dispatch(updateSearch(json)),
                 error => dispatch(courseSearchError(error)),
             ),
             error => dispatch(courseSearchError(error)),

--- a/frontend/plan/src/actions/index.js
+++ b/frontend/plan/src/actions/index.js
@@ -144,21 +144,6 @@ export const clearSchedule = () => (
     }
 );
 
-export function requestSearch(searchData) {
-    return {
-        type: REQUEST_SEARCH,
-        searchData,
-    };
-}
-
-
-export function requestSectionInfo(courseData) {
-    return {
-        type: REQUEST_SECTION_INFO_SEARCH,
-        courseData,
-    };
-}
-
 const SEMESTER = "2019C";
 
 function buildCourseSearchUrl(searchData) {
@@ -185,22 +170,20 @@ export function sectionInfoSearchError(error) {
 }
 
 export function fetchCourseSearch(searchData) {
-    return (dispatch) => {
-        dispatch(requestSearch(searchData));
-        return fetch(buildCourseSearchUrl(searchData)).then(
+    return dispatch => (
+        fetch(buildCourseSearchUrl(searchData)).then(
             response => response.json().then(
                 json => dispatch(updateSearch(json)),
                 error => dispatch(courseSearchError(error)),
             ),
             error => dispatch(courseSearchError(error)),
-        );
-    };
+        )
+    );
 }
 
 export function fetchSectionInfo(searchData) {
-    return (dispatch) => {
-        dispatch(requestSectionInfo(searchData));
-        return fetch(buildSectionInfoSearchUrl(searchData)).then(
+    return dispatch => (
+        fetch(buildSectionInfoSearchUrl(searchData)).then(
             response => response.json().then(
                 (json) => {
                     const info = {
@@ -214,8 +197,8 @@ export function fetchSectionInfo(searchData) {
                 error => dispatch(sectionInfoSearchError(error)),
             ),
             error => dispatch(sectionInfoSearchError(error)),
-        );
-    };
+        )
+    );
 }
 
 export function courseSearchLoading() {

--- a/frontend/plan/src/actions/index.js
+++ b/frontend/plan/src/actions/index.js
@@ -1,8 +1,9 @@
 import fetch from "cross-fetch";
 
 export const UPDATE_SEARCH = "UPDATE_SEARCH";
-export const UPDATE_SECTIONS = "UPDATE_SECTIONS";
 
+export const UPDATE_COURSE_INFO = "UPDATE_COURSE_INFO";
+export const UPDATE_SECTIONS = "UPDATE_SECTIONS";
 export const OPEN_SECTION_INFO = "OPEN_SECTION_INFO";
 export const CHANGE_SCHEDULE = "CHANGE_SCHEDULE";
 export const CREATE_SCHEDULE = "CREATE_SCHEDULE";
@@ -65,10 +66,10 @@ export const addSchedItem = courseObj => (
     }
 );
 
-export const removeSchedItem = idDashed => (
+export const removeSchedItem = id => (
     {
         type: REMOVE_SCHED_ITEM,
-        idDashed,
+        id,
     }
 );
 
@@ -90,6 +91,14 @@ export const updateSectionInfo = sectionInfo => (
     {
         type: OPEN_SECTION_INFO,
         sectionInfo,
+    }
+);
+
+export const updateCourseInfo = (sections, info) => (
+    {
+        type: UPDATE_COURSE_INFO,
+        info,
+        sections,
     }
 );
 
@@ -150,19 +159,6 @@ export function requestSectionInfo(courseData) {
     };
 }
 
-
-const preprocessCourseSearchData = (searchData) => {
-    const data = searchData;
-    data.param = data.param.replace(/\s/, "");
-    if (/\d/.test(searchData.param)) {
-        data.resultType = "numbSearch";
-    } else {
-        data.resultType = "deptSearch";
-    }
-    return data;
-};
-
-
 const SEMESTER = "2019C";
 
 function buildCourseSearchUrl(searchData) {
@@ -206,7 +202,15 @@ export function fetchSectionInfo(searchData) {
         dispatch(requestSectionInfo(searchData));
         return fetch(buildSectionInfoSearchUrl(searchData)).then(
             response => response.json().then(
-                json => dispatch(updateSectionInfo(json)),
+                (json) => {
+                    const info = {
+                        id: json.id,
+                        description: json.description,
+                        crosslistings: json.crosslistings,
+                    };
+                    const { sections } = json;
+                    dispatch(updateCourseInfo(sections, info));
+                },
                 error => dispatch(sectionInfoSearchError(error)),
             ),
             error => dispatch(sectionInfoSearchError(error)),

--- a/frontend/plan/src/components/Badge.js
+++ b/frontend/plan/src/components/Badge.js
@@ -1,0 +1,27 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export default function Badge(props) {
+    const range = 4;
+    const { baseColor, value } = props;
+    const frac = value / range;
+    const opacity = (frac ** 3) * 2;
+    const textColor = frac < 0.5 ? "black" : "white";
+
+    return (
+        <span
+            className="PCR"
+            style={{
+                background: `rgba(${baseColor[0]}, ${baseColor[1]}, ${baseColor[2]}, ${opacity})`,
+                color: textColor,
+            }}
+        >
+            {value}
+        </span>
+    );
+}
+
+Badge.propTypes = {
+    baseColor: PropTypes.arrayOf(PropTypes.number).isRequired,
+    value: PropTypes.number.isRequired,
+};

--- a/frontend/plan/src/components/schedule/Block.js
+++ b/frontend/plan/src/components/schedule/Block.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 export default function Block(props) {
     const days = ["M", "T", "W", "R", "F", "S", "U"];
     const {
-        offsets, meeting, course, remove, style,
+        offsets, meeting, course, remove, style, focusSection,
     } = props;
     const { day, start, end } = meeting;
     const { id, color, coreqFulfilled } = course;
@@ -15,7 +15,12 @@ export default function Block(props) {
         position: "relative",
     };
     return (
-        <div className={`block ${color}`} style={{ ...pos, ...style }}>
+        <div
+            role="button"
+            className={`block ${color}`}
+            style={{ ...pos, ...style }}
+            onClick={focusSection}
+        >
             <div className="inner-block">
                 <span
                     role="button"
@@ -60,4 +65,5 @@ Block.propTypes = {
         width: PropTypes.string,
         left: PropTypes.string,
     }),
+    focusSection: PropTypes.func,
 };

--- a/frontend/plan/src/components/schedule/Schedule.js
+++ b/frontend/plan/src/components/schedule/Schedule.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import connect from "react-redux/es/connect/connect";
 
-import { removeSchedItem } from "../../actions";
+import { removeSchedItem, fetchSectionInfo } from "../../actions";
 
 import "./schedule.css";
 import Days from "./Days";
@@ -80,7 +80,7 @@ export const getConflictGroups = (meetings) => {
 
 class Schedule extends Component {
     render() {
-        const { schedData, removeSection } = this.props;
+        const { schedData, removeSection, focusSection } = this.props;
         const sections = schedData.meetings || [];
 
         if (sections.length < 1) {
@@ -115,7 +115,7 @@ class Schedule extends Component {
                     // if we've used all the colors, it's acceptable to start reusing colors.
                     used = [];
                 }
-                let i = hashString(c);
+                let i = Math.abs(hashString(c));
                 while (used.indexOf(colors[i % colors.length]) !== -1) {
                     i += 1;
                 }
@@ -139,9 +139,10 @@ class Schedule extends Component {
                     course: {
                         color,
                         id: s.id,
-                        coreqFulfilled: s.associated_sections.filter(
-                            coreq => sectionIds.indexOf(coreq.id) !== -1
-                        ).length > 0,
+                        coreqFulfilled: s.associated_sections.length === 0 ||
+                            s.associated_sections.filter(
+                                coreq => sectionIds.indexOf(coreq.id) !== -1
+                            ).length > 0,
                     },
                     style: {
                         width: "100%",
@@ -185,6 +186,10 @@ class Schedule extends Component {
                 }}
                 key={`${meeting.course.id}-${meeting.data.day}`}
                 remove={() => removeSection(meeting.course.id)}
+                focusSection={() => {
+                    const split = meeting.course.id.split("-");
+                    focusSection(`${split[0]}-${split[1]}`);
+                }}
             />
         ));
 
@@ -230,6 +235,7 @@ const mapStateToProps = state => (
 const mapDispatchToProps = dispatch => (
     {
         removeSection: idDashed => dispatch(removeSchedItem(idDashed)),
+        focusSection: id => dispatch(fetchSectionInfo({ param: id })),
     }
 );
 

--- a/frontend/plan/src/components/schedule/Schedule.js
+++ b/frontend/plan/src/components/schedule/Schedule.js
@@ -124,11 +124,11 @@ class Schedule extends Component {
                 return color;
             };
         })();
-        const sectionIds = sections.map(x => x.sectionId);
+        const sectionIds = sections.map(x => x.id);
         // a meeting is the data that represents a single block on the schedule.
         const meetings = [];
         sections.forEach((s) => {
-            const color = getColor(s.sectionId);
+            const color = getColor(s.id);
             meetings.push(...s.meetings.map(m => (
                 {
                     data: {
@@ -138,7 +138,7 @@ class Schedule extends Component {
                     },
                     course: {
                         color,
-                        id: s.sectionId,
+                        id: s.id,
                         coreqFulfilled: s.associated_sections.filter(
                             coreq => sectionIds.indexOf(coreq.id) !== -1
                         ).length > 0,

--- a/frontend/plan/src/components/schedule/Schedule.js
+++ b/frontend/plan/src/components/schedule/Schedule.js
@@ -139,8 +139,8 @@ class Schedule extends Component {
                     course: {
                         color,
                         id: s.id,
-                        coreqFulfilled: s.associated_sections.length === 0 ||
-                            s.associated_sections.filter(
+                        coreqFulfilled: s.associated_sections.length === 0
+                            || s.associated_sections.filter(
                                 coreq => sectionIds.indexOf(coreq.id) !== -1
                             ).length > 0,
                     },

--- a/frontend/plan/src/components/search/bar.js
+++ b/frontend/plan/src/components/search/bar.js
@@ -68,24 +68,6 @@ class SearchBar extends Component {
         return (
             <div id="searchbar" className="level">
                 <span className="level-left">
-
-                    <div id="searchSelectContainer">
-                        <Dropdown
-                            id="searchSelect"
-                            updateLabel={true}
-                            defActive={0}
-                            defText="Search By"
-                            contents={[
-                                ["Course ID", () => {
-                                }],
-                                ["Keywords", () => {
-                                }],
-                                ["Instructor", () => {
-                                }]
-                            ]}
-                        />
-                    </div>
-
                     <form
                         onSubmit={this.handleSubmit}
                     >

--- a/frontend/plan/src/components/search/bar.js
+++ b/frontend/plan/src/components/search/bar.js
@@ -132,7 +132,7 @@ class SearchBar extends Component {
                     </div>
 
                     {/* Course summary dropdown */}
-                    <SummaryDropdown />
+                    {/*<SummaryDropdown />*/}
                     <SchedulesDropdown
                         scheduleNames={scheduleNames}
                         scheduleSelected={scheduleSelected}

--- a/frontend/plan/src/components/search/search_result.js
+++ b/frontend/plan/src/components/search/search_result.js
@@ -6,7 +6,7 @@ import Badge from "../Badge";
 export function SearchResult({ course, requestSectionInfo }) {
     return (
         <li
-            id={course.course_id}
+            id={course.id}
             onClick={() => requestSectionInfo()}
             role="menuitem"
         >
@@ -20,7 +20,7 @@ export function SearchResult({ course, requestSectionInfo }) {
             />
 
             <span className="cID">
-                {course.course_id}
+                {course.id}
             </span>
             &nbsp;
             <span className="cTitle">

--- a/frontend/plan/src/components/search/search_result.js
+++ b/frontend/plan/src/components/search/search_result.js
@@ -1,39 +1,30 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import Badge from "../Badge";
+
 export function SearchResult({ course, requestSectionInfo }) {
     return (
         <li
-            id={course.idDashed}
+            id={course.course_id}
             onClick={() => requestSectionInfo()}
             role="menuitem"
         >
-            <span
-                className="PCR Qual"
-                style={{
-                    background: `rgba(45, 160, 240, ${course.pcrQShade})`,
-                    color: course.pcrQColor,
-                }}
-            >
-                {course.revs.cQ || course.revs.cQT}
-            </span>
-
-            <span
-                className="PCR Diff"
-                style={{
-                    background: `rgba(231, 76, 60, ${course.pcrDShade})`,
-                    color: course.pcrDColor,
-                }}
-            >
-                {course.revs.cD || course.revs.cDT}
-            </span>
+            <Badge
+                baseColor={[45, 160, 240]}
+                value={2.0}
+            />
+            <Badge
+                baseColor={[231, 76, 60]}
+                value={4.0}
+            />
 
             <span className="cID">
-                {course.idSpaced}
+                {course.course_id}
             </span>
-
+            &nbsp;
             <span className="cTitle">
-                {course.courseTitle}
+                {course.title}
             </span>
 
         </li>

--- a/frontend/plan/src/components/search/search_results.js
+++ b/frontend/plan/src/components/search/search_results.js
@@ -15,7 +15,7 @@ function SearchResults({ searchResults, requestSectionInfo }) {
                 <SearchResult
                     key={i}
                     course={searchResult}
-                    requestSectionInfo={() => requestSectionInfo(searchResult.idSpaced)}
+                    requestSectionInfo={() => requestSectionInfo(searchResult.id)}
                 />
             );
             items.push(searchResultComponent);

--- a/frontend/plan/src/components/selector/SectionDisplay.js
+++ b/frontend/plan/src/components/selector/SectionDisplay.js
@@ -57,12 +57,7 @@ export default class SectionDisplay extends Component {
         const {
             addSchedItem,
             removeSchedItem,
-            section: {
-                revs,
-                meetings,
-                id,
-                associated_sections,
-            },
+            section,
             inSchedule,
         } = this.props;
 
@@ -76,16 +71,11 @@ export default class SectionDisplay extends Component {
 
         if (!inSchedule) {
             onClick = () => {
-                addSchedItem({
-                    meetings,
-                    revs,
-                    sectionId: id,
-                    associated_sections,
-                });
+                addSchedItem(section);
             };
         } else {
             onClick = () => {
-                removeSchedItem(id);
+                removeSchedItem(section.id);
             };
         }
 

--- a/frontend/plan/src/components/selector/SectionDisplay.js
+++ b/frontend/plan/src/components/selector/SectionDisplay.js
@@ -136,7 +136,7 @@ export default class SectionDisplay extends Component {
                     <div className="column is-one-fifth">
                         { this.getAddRemoveIcon() }
                         <span className="icon">
-                            {!section.isOpen ? this.getPcaButton()
+                            {(section.status !== "O") ? this.getPcaButton()
                                 : (
                                     <i className="fas fa-square has-text-success" />
                                 )

--- a/frontend/plan/src/components/selector/SectionDisplay.js
+++ b/frontend/plan/src/components/selector/SectionDisplay.js
@@ -1,12 +1,55 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
+import Badge from "../Badge";
+
 export default class SectionDisplay extends Component {
     stripTime = (s) => {
         let newS = s.replace(" to ", "-");
         newS = newS.replace("on", "");
         return newS;
-    }
+    };
+
+    getTimeString = (meetings) => {
+        const intToTime = (t) => {
+            let hour = Math.floor(t % 12);
+            let min = Math.round((t % 1) * 100);
+            if (hour === 0) {
+                hour = 12;
+            }
+            if (min === 0) {
+                min = "00";
+            }
+            return `${hour}:${min}`;
+        };
+        const times = {};
+        let maxcount = 0;
+        let maxrange = null;
+        meetings.forEach((meeting) => {
+            const rangeId = `${meeting.start}-${meeting.end}`;
+            if (!times[rangeId]) {
+                times[rangeId] = [meeting.day];
+            } else {
+                times[rangeId].push(meeting.day);
+            }
+            if (times[rangeId].length > maxcount) {
+                maxcount = times[rangeId].length;
+                maxrange = rangeId;
+            }
+        });
+
+        const days = ["M", "T", "W", "R", "F", "S", "U"];
+        let daySet = "";
+        days.forEach((day) => {
+            times[maxrange].forEach((d) => {
+                if (d === day) {
+                    daySet += day;
+                }
+            });
+        })
+
+        return `${intToTime(maxrange.split("-")[0])}-${intToTime(maxrange.split("-")[1])} ${daySet}`;
+    };
 
     justSection = s => s.substring(s.lastIndexOf(" ") + 1);
 
@@ -16,7 +59,9 @@ export default class SectionDisplay extends Component {
             removeSchedItem,
             section: {
                 revs,
-                fullSchedInfo,
+                meetings,
+                id,
+                associated_sections,
             },
             inSchedule,
         } = this.props;
@@ -31,11 +76,16 @@ export default class SectionDisplay extends Component {
 
         if (!inSchedule) {
             onClick = () => {
-                addSchedItem({ ...fullSchedInfo[0], revs });
+                addSchedItem({
+                    meetings,
+                    revs,
+                    sectionId: id,
+                    associated_sections,
+                });
             };
         } else {
             onClick = () => {
-                removeSchedItem(fullSchedInfo[0].fullID);
+                removeSchedItem(id);
             };
         }
 
@@ -58,25 +108,12 @@ export default class SectionDisplay extends Component {
         );
     }
 
-    getInstructorReview = () => {
-        const {
-            section: {
-                revs,
-                pcrIShade,
-                pcrIColor,
-            },
-        } = this.props;
-
-        const bgColor = `rgba(46, 204, 113, ${pcrIShade})`;
-        return (
-            <span
-                className="PCR Inst"
-                style={{ background: bgColor, color: pcrIColor, marginTop: "2px" }}
-            >
-                { revs.cI }
-            </span>
-        );
-    }
+    getInstructorReview = () => (
+        <Badge
+            baseColor={[46, 204, 113]}
+            value={3}
+        />
+    );
 
     render() {
         const {
@@ -96,13 +133,9 @@ export default class SectionDisplay extends Component {
         if (overlap) {
             className += " hideSec";
         }
-        /* if((!$scope.sched.SecOverlap(this.section)
-            && $scope.schedSections.indexOf(this.section.idDashed) === -1)){
-            className += "hideSec";
-        } */
         return (
             <li
-                id={section.idDashed}
+                id={section.id}
                 className={className}
                 onClick={openSection}
                 style={{ cursor: "pointer" }}
@@ -130,7 +163,7 @@ export default class SectionDisplay extends Component {
                         <span
                             className="sectionText"
                         >
-                            { this.justSection(section.idSpaced) }
+                            { this.justSection(section.id.replace(/-/g, " ")) }
                         </span>
                     </div>
 
@@ -138,7 +171,7 @@ export default class SectionDisplay extends Component {
                         <span
                             className="sectionText"
                         >
-                            { this.stripTime(section.timeInfo) }
+                            { this.getTimeString(section.meetings) }
                         </span>
                     </div>
                 </div>

--- a/frontend/plan/src/components/selector/SectionList.js
+++ b/frontend/plan/src/components/selector/SectionList.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import SectionDisplay from "./SectionDisplay";
-import { sectionInfoA } from "../../sections_data";
 
 export default function SectionList(props) {
     const {
@@ -18,14 +17,14 @@ export default function SectionList(props) {
         const section = sections[i];
         sectionsArr.push(
             <SectionDisplay
-                inSchedule={scheduleContains(section.idDashed)}
+                inSchedule={scheduleContains(section.id)}
                 overlap={overlaps(section)}
                 addSchedItem={addSchedItem}
                 removeSchedItem={removeSchedItem}
                 section={section}
                 key={i}
                 openSection={() => {
-                    updateSectionInfo(sectionInfoA);
+                    updateSectionInfo(sections);
                 }}
             />
         );

--- a/frontend/plan/src/components/selector/Sections.js
+++ b/frontend/plan/src/components/selector/Sections.js
@@ -30,29 +30,21 @@ const mapStateToProps = state => (
     }
 );
 
-// generates a list of meeting times in the form [day, start hour, end hour]
-// from a meetingInfo object
-const generateMeetingTimes = (meetingInfo) => {
-    const meetingTimes = [];
-    for (let i = 0; i < meetingInfo.meetDay.length; i += 1) {
-        meetingTimes.push([meetingInfo.meetDay[i], meetingInfo.meetHour,
-            meetingInfo.meetHour + meetingInfo.hourLength]);
-    }
-    return meetingTimes;
-};
-
 // finds intersections between meeting times
 const meetingTimeIntersection = (meetingTimesA, meetingTimesB) => {
+    const overlap = (m1, m2) => {
+        const start1 = m1.start;
+        const start2 = m2.start;
+        const end1 = m1.end;
+        const end2 = m2.end;
+        return m1.day === m2.day && !(end1 <= start2 || end2 <= start1);
+    };
     for (let i = 0; i < meetingTimesA.length; i += 1) {
         for (let j = 0; j < meetingTimesB.length; j += 1) {
             const meetingA = meetingTimesA[i];
             const meetingB = meetingTimesB[j];
-            if (meetingA[0] === meetingB[0]) {
-                const rangeUnion = [Math.max(meetingA[1], meetingB[1]),
-                    Math.min(meetingA[2], meetingB[2])];
-                if (rangeUnion[0] < rangeUnion[1]) {
-                    return true;
-                }
+            if (overlap(meetingA, meetingB)) {
+                return true;
             }
         }
     }
@@ -65,8 +57,7 @@ class Sections extends Component {
         const {
             scheduleMeetings,
         } = this.props;
-
-        return scheduleMeetings.map(section => section.idDashed).indexOf(sectionID) !== -1;
+        return scheduleMeetings.map(section => section.sectionId).indexOf(sectionID) !== -1;
     }
 
     render() {
@@ -121,21 +112,11 @@ class Sections extends Component {
                     <SectionList
                         updateSectionInfo={updateSectionInfo}
                         scheduleContains={this.scheduleContains}
-                        overlaps={(meeting) => {
-                            if (this.scheduleContains(meeting.idDashed)) {
+                        overlaps={(section) => {
+                            if (this.scheduleContains(section.id)) {
                                 return false;
                             }
-                            let meetingTimes = [];
-                            meeting.fullSchedInfo.forEach((meetingInfo) => {
-                                meetingTimes = meetingTimes
-                                    .concat(generateMeetingTimes(meetingInfo));
-                            });
-                            let otherMeetingTimes = [];
-                            scheduleMeetings.forEach((meetingInfo) => {
-                                otherMeetingTimes = otherMeetingTimes
-                                    .concat(generateMeetingTimes(meetingInfo));
-                            });
-                            return meetingTimeIntersection(otherMeetingTimes, meetingTimes);
+                            return meetingTimeIntersection(scheduleMeetings, section.meetings);
                         }}
                         sections={sections}
                         addSchedItem={addSchedItem}

--- a/frontend/plan/src/components/selector/Sections.js
+++ b/frontend/plan/src/components/selector/Sections.js
@@ -54,10 +54,8 @@ const meetingTimeIntersection = (meetingTimesA, meetingTimesB) => {
 
 class Sections extends Component {
     scheduleContains = (sectionID) => {
-        const {
-            scheduleMeetings,
-        } = this.props;
-        return scheduleMeetings.map(section => section.sectionId).indexOf(sectionID) !== -1;
+        const { scheduleMeetings } = this.props;
+        return scheduleMeetings.map(section => section.id).indexOf(sectionID) !== -1;
     }
 
     render() {
@@ -116,7 +114,11 @@ class Sections extends Component {
                             if (this.scheduleContains(section.id)) {
                                 return false;
                             }
-                            return meetingTimeIntersection(scheduleMeetings, section.meetings);
+                            return meetingTimeIntersection(
+                                scheduleMeetings
+                                    .map(sec => sec.meetings)
+                                    .reduce((acc, val) => acc.concat(val)), section.meetings
+                            );
                         }}
                         sections={sections}
                         addSchedItem={addSchedItem}

--- a/frontend/plan/src/components/selector/Sections.js
+++ b/frontend/plan/src/components/selector/Sections.js
@@ -10,6 +10,7 @@ import {
     updateSectionInfo,
     updateSections
 } from "../../actions";
+import { meetingSetsIntersect } from "../../meetUtil";
 
 const mapDispatchToProps = dispatch => (
     {
@@ -29,27 +30,6 @@ const mapStateToProps = state => (
             .meetings : [],
     }
 );
-
-// finds intersections between meeting times
-const meetingTimeIntersection = (meetingTimesA, meetingTimesB) => {
-    const overlap = (m1, m2) => {
-        const start1 = m1.start;
-        const start2 = m2.start;
-        const end1 = m1.end;
-        const end2 = m2.end;
-        return m1.day === m2.day && !(end1 <= start2 || end2 <= start1);
-    };
-    for (let i = 0; i < meetingTimesA.length; i += 1) {
-        for (let j = 0; j < meetingTimesB.length; j += 1) {
-            const meetingA = meetingTimesA[i];
-            const meetingB = meetingTimesB[j];
-            if (overlap(meetingA, meetingB)) {
-                return true;
-            }
-        }
-    }
-    return false;
-};
 
 
 class Sections extends Component {
@@ -114,10 +94,13 @@ class Sections extends Component {
                             if (this.scheduleContains(section.id)) {
                                 return false;
                             }
-                            return meetingTimeIntersection(
+                            return meetingSetsIntersect(
+                                // get all meetings from the current schedule.
                                 scheduleMeetings
                                     .map(sec => sec.meetings)
-                                    .reduce((acc, val) => acc.concat(val), []), section.meetings
+                                    .reduce((acc, val) => acc.concat(val), []),
+                                // and see if they intersect with this section's meeting times.
+                                section.meetings
                             );
                         }}
                         sections={sections}

--- a/frontend/plan/src/components/selector/Sections.js
+++ b/frontend/plan/src/components/selector/Sections.js
@@ -117,7 +117,7 @@ class Sections extends Component {
                             return meetingTimeIntersection(
                                 scheduleMeetings
                                     .map(sec => sec.meetings)
-                                    .reduce((acc, val) => acc.concat(val)), section.meetings
+                                    .reduce((acc, val) => acc.concat(val), []), section.meetings
                             );
                         }}
                         sections={sections}

--- a/frontend/plan/src/meetUtil.js
+++ b/frontend/plan/src/meetUtil.js
@@ -1,0 +1,69 @@
+/*
+ * This file contains functions which are generally useful when dealing with meeting times
+ * in the current schema. It's expecting either single objects, or arrays of objects, in
+ * which contain `day`, `start` and `end` fields, where `start` and `end` are numbers in
+ * the format HH.MM.
+ */
+
+export const meetingsOverlap = (m1, m2) => {
+    const start1 = m1.start;
+    const start2 = m2.start;
+    const end1 = m1.end;
+    const end2 = m2.end;
+    return m1.day === m2.day && !(end1 <= start2 || end2 <= start1);
+};
+
+// From an array of meetings, get the groups which conflict in timing.
+export const getConflictGroups = (meetings) => {
+    for (let i = 0; i < meetings.length; i += 1) {
+        // eslint-disable-next-line
+        meetings[i].id = i;
+    }
+
+    // `conflicts` is a union-find datastructure representing "conflict sets".
+    // https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+    // meetings m1 and m2 are in the same conflict set if m1 and m2 conflict
+    // with at least one meeting m3 which is also in the set (m3 can be m1 or m2).
+    const conflicts = {};
+    const merge = (m1, m2) => {
+        conflicts[m2.id] = new Set(
+            [...conflicts[m1.id], ...conflicts[m2.id]]
+        );
+        conflicts[m1.id] = conflicts[m2.id];
+    };
+
+    meetings.forEach((m) => {
+        conflicts[m.id] = new Set([m]);
+    });
+
+    // compare every pair of meetings. if they overlap, merge their sets.
+    for (let i = 0; i < meetings.length - 1; i += 1) {
+        for (let j = i + 1; j < meetings.length; j += 1) {
+            if (meetingsOverlap(meetings[i], meetings[j])) {
+                merge(meetings[i], meetings[j]);
+            }
+        }
+    }
+
+    // remove sets of size 1 from the results; they're not conflicting with anything.
+    Object.keys(conflicts).forEach((key) => {
+        if (conflicts[key].size <= 1) {
+            delete conflicts[key];
+        }
+    });
+    // use a Set to remove duplicates, so we get only unique conflict sets.
+    return Array.from(new Set(Object.values(conflicts)).values());
+};
+
+export const meetingSetsIntersect = (meetingTimesA, meetingTimesB) => {
+    for (let i = 0; i < meetingTimesA.length; i += 1) {
+        for (let j = 0; j < meetingTimesB.length; j += 1) {
+            const meetingA = meetingTimesA[i];
+            const meetingB = meetingTimesB[j];
+            if (meetingsOverlap(meetingA, meetingB)) {
+                return true;
+            }
+        }
+    }
+    return false;
+};

--- a/frontend/plan/src/reducers/schedule.js
+++ b/frontend/plan/src/reducers/schedule.js
@@ -114,7 +114,7 @@ export const schedule = (state = initialState, action) => {
                     [state.scheduleSelected]: {
                         ...state[state.scheduleSelected],
                         meetings: state.schedules[state.scheduleSelected].meetings
-                            .filter(m => m.fullID !== action.idDashed),
+                            .filter(m => m.sectionId !== action.id),
                     },
                 },
             };

--- a/frontend/plan/src/reducers/schedule.js
+++ b/frontend/plan/src/reducers/schedule.js
@@ -114,7 +114,7 @@ export const schedule = (state = initialState, action) => {
                     [state.scheduleSelected]: {
                         ...state[state.scheduleSelected],
                         meetings: state.schedules[state.scheduleSelected].meetings
-                            .filter(m => m.sectionId !== action.id),
+                            .filter(m => m.id !== action.id),
                     },
                 },
             };

--- a/frontend/plan/src/reducers/sections.js
+++ b/frontend/plan/src/reducers/sections.js
@@ -3,9 +3,9 @@ import {
     OPEN_SECTION_INFO,
     TOGGLE_SEARCH_FILTER,
     UPDATE_SEARCH,
-    UPDATE_SECTIONS
+    UPDATE_SECTIONS,
+    UPDATE_COURSE_INFO
 } from "../actions";
-import { sectionsDataA } from "../sections_data";
 
 // This file contains the reducers for everything related to sections and courses
 
@@ -16,7 +16,7 @@ import { sectionsDataA } from "../sections_data";
 // 4. Whether to display the search filter
 // 5. The coordinates of the search filter button
 const initialState = {
-    sections: sectionsDataA,
+    sections: [],
     searchResults: [],
     sectionInfo: undefined,
     showSearchFilter: false,
@@ -25,6 +25,12 @@ const initialState = {
 
 export const sections = (state = initialState, action) => {
     switch (action.type) {
+        case UPDATE_COURSE_INFO:
+            return {
+                ...state,
+                sectionInfo: action.info,
+                sections: action.sections,
+            };
         case OPEN_SECTION_INFO:
             return {
                 ...state,


### PR DESCRIPTION
This PR updates frontend API endpoints and expected JSON schema so that the new, frontend can query from and display information from the Django REST framework backend. This touches a lot of files, on both frontend and backend.

The rationale behind changing the schema was that generally, the old schema was pretty esoteric. As an example, the ending of a meeting block could be found with `startHour + hourLength`, which doesn't make too much semantic sense.

Still to-do after this PR:
- Display crosslistings
- Add requirements to API response
- Add PCR ratings to courses
- Generally add more info on courses to API