### PR TITLE
Refactor and filtering by requirement

### DIFF
--- a/PennCourses/urls/pcp.py
+++ b/PennCourses/urls/pcp.py
@@ -1,5 +1,5 @@
 from .base import *
 
 urlpatterns = [
-    path('registrar/', include('courses.urls')),
+    path('', include('plan.urls')),
 ] + urlpatterns

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -56,7 +56,7 @@ class MeetingAdmin(admin.ModelAdmin):
 
 
 class RequirementAdmin(admin.ModelAdmin):
-    autocomplete_fields = ('departments', 'courses')
+    autocomplete_fields = ('departments', 'courses', 'overrides')
 
 
 admin.site.register(Department, DepartmentAdmin)

--- a/courses/tests.py
+++ b/courses/tests.py
@@ -197,36 +197,6 @@ API Test Cases
 '''
 
 
-class TypedSearchBackendTestCase(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.search = TypedSearchBackend()
-
-    def test_type_course(self):
-        req = self.factory.get('/', {'type': 'course', 'search': 'ABC123'})
-        terms = self.search.get_search_fields(None, req)
-        self.assertEqual(['full_code'], terms)
-
-    def test_type_keyword(self):
-        req = self.factory.get('/', {'type': 'keyword', 'search': 'ABC123'})
-        terms = self.search.get_search_fields(None, req)
-        self.assertEqual(['title', 'sections__instructors__name'], terms)
-
-    def test_auto_course(self):
-        courses = ['cis', 'CIS', 'cis120', 'anch-027', 'cis 121', 'ling-140']
-        for course in courses:
-            req = self.factory.get('/', {'type': 'auto', 'search': course})
-            terms = self.search.get_search_fields(None, req)
-            self.assertEqual(['full_code'], terms, f'search:{course}')
-
-    def test_auto_keyword(self):
-        keywords = ['rajiv', 'gandhi', 'programming', 'hello world']
-        for kw in keywords:
-            req = self.factory.get('/', {'type': 'auto', 'search': kw})
-            terms = self.search.get_search_fields(None, req)
-            self.assertEqual(['title', 'sections__instructors__name'], terms, f'search:{kw}')
-
-
 @override_settings(SWITCHBOARD_TEST_APP='api')
 class CourseListTestCase(TestCase):
     def setUp(self):
@@ -238,24 +208,8 @@ class CourseListTestCase(TestCase):
     def test_get_courses(self):
         response = self.client.get('/all/courses/')
         self.assertEqual(len(response.data), 2)
-        course_codes = [d['course_id'] for d in response.data]
+        course_codes = [d['id'] for d in response.data]
         self.assertTrue('CIS-120' in course_codes and 'MATH-114' in course_codes)
-
-    def test_search_by_dept(self):
-        response = self.client.get('/all/courses/', {'search': 'math', 'type': 'auto'})
-        self.assertEqual(len(response.data), 1)
-        course_codes = [d['course_id'] for d in response.data]
-        self.assertTrue('CIS-120' not in course_codes and 'MATH-114' in course_codes)
-
-    def test_search_by_instructor(self):
-        self.section.instructors.add(Instructor.objects.get_or_create(name='Tiffany Chang')[0])
-        self.math1.instructors.add(Instructor.objects.get_or_create(name='Josh Doman')[0])
-        searches = ['Tiffany', 'Chang']
-        for search in searches:
-            response = self.client.get('/all/courses/', {'search': search, 'type': 'auto'})
-            self.assertEqual(len(response.data), 1)
-            course_codes = [d['course_id'] for d in response.data]
-            self.assertTrue('CIS-120' in course_codes and 'MATH-114' not in course_codes, f'search:{search}')
 
     def test_semester_setting(self):
         new_sem = TEST_SEMESTER[:-1] + 'Z'
@@ -288,7 +242,7 @@ class SectionListTestCase(TestCase):
     def test_get_sections(self):
         response = self.client.get('/all/sections/')
         self.assertEqual(len(response.data), 2)
-        codes = [d['section_id'] for d in response.data]
+        codes = [d['id'] for d in response.data]
         self.assertTrue('CIS-120-001' in codes and 'CIS-120-002' in codes)
 
 
@@ -304,7 +258,7 @@ class CourseDetailTestCase(TestCase):
         course, section = get_course_and_section('CIS-120-201', TEST_SEMESTER)
         response = self.client.get('/all/courses/CIS-120/')
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.data['course_id'], 'CIS-120')
+        self.assertEqual(response.data['id'], 'CIS-120')
         self.assertEqual(len(response.data['sections']), 2)
 
     def test_not_get_course(self):

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('<slug:semester>/sections/', views.SectionList.as_view()),
     path('<slug:semester>/courses/', views.CourseList.as_view()),
     path('<slug:semester>/courses/<slug:full_code>/',  views.CourseDetail.as_view()),
+    path('<slug:semester>/requirements/', views.RequirementList.as_view()),
 ]

--- a/courses/views.py
+++ b/courses/views.py
@@ -12,14 +12,19 @@ class BaseCourseMixin(generics.GenericAPIView):
     def get_semester_field():
         return 'semester'
 
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        queryset = self.get_serializer_class().setup_eager_loading(queryset)
-        # if we're in a view without a semester parameter, only return the current semester.
+    def get_semester(self):
         semester = self.kwargs.get('semester', 'current')
         if semester == 'current':
             semester = get_value('SEMESTER', 'all')
 
+        return semester
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        queryset = self.get_serializer_class().setup_eager_loading(queryset)
+
+        # if we're in a view without a semester parameter, only return the current semester.
+        semester = self.get_semester()
         if semester != 'all':
             queryset = queryset.filter(**{self.get_semester_field(): semester})
         return queryset
@@ -43,6 +48,11 @@ class CourseDetail(generics.RetrieveAPIView, BaseCourseMixin):
     serializer_class = CourseDetailSerializer
     lookup_field = 'full_code'
     queryset = Course.objects.all()
+
+
+class RequirementList(generics.ListAPIView, BaseCourseMixin):
+    serializer_class = RequirementListSerializer
+    queryset = Requirement.objects.all()
 
 
 def index(request):

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,51 +1,10 @@
-import re
-
-from django.shortcuts import render
 from django.http import HttpResponse
-from rest_framework import mixins, generics, filters
-
-from options.models import get_value
+from rest_framework import generics
 
 from .serializers import *
 from .models import *
 
-
-class TypedSearchBackend(filters.SearchFilter):
-    code_re = re.compile(r'^([A-Za-z]{1,4})?[ |-]?(\d{1,5})?$')
-
-    def infer_search_type(self, query):
-        if self.code_re.match(query):
-            return 'course'
-        else:
-            return 'keyword'
-
-    @staticmethod
-    def get_search_type(request):
-        return request.GET.get('type', 'auto')
-
-    def get_search_terms(self, request):
-        search_type = self.get_search_type(request)
-        query = request.query_params.get(self.search_param, '')
-
-        match = self.code_re.match(query)
-        # If this is a course query, either by designation or by detection,
-        if (search_type == 'course' or (search_type == 'auto' and self.infer_search_type(query) == 'course')) \
-                and match and match.group(1) and match.group(2):
-            query = f'{match.group(1)}-{match.group(2)}'
-        return [query]
-
-    def get_search_fields(self, view, request):
-        search_type = self.get_search_type(request)
-
-        if search_type == 'auto':
-            search_type = self.infer_search_type(request.GET.get('search'))
-
-        if search_type == 'course':
-            return ['full_code']
-        elif search_type == 'keyword':
-            return ['title', 'sections__instructors__name']
-        else:
-            return super().get_search_fields(view, request)
+from options.models import get_value
 
 
 class BaseCourseMixin(generics.GenericAPIView):
@@ -56,7 +15,8 @@ class BaseCourseMixin(generics.GenericAPIView):
     def get_queryset(self):
         queryset = super().get_queryset()
         queryset = self.get_serializer_class().setup_eager_loading(queryset)
-        semester = self.kwargs.get('semester', 'all')
+        # if we're in a view without a semester parameter, only return the current semester.
+        semester = self.kwargs.get('semester', 'current')
         if semester == 'current':
             semester = get_value('SEMESTER', 'all')
 
@@ -76,8 +36,6 @@ class SectionList(generics.ListAPIView, BaseCourseMixin):
 
 class CourseList(generics.ListAPIView, BaseCourseMixin):
     serializer_class = CourseListSerializer
-    filter_backends = (TypedSearchBackend,)
-    search_fields = ('full_code', 'title', 'sections__instructors__name')
     queryset = Course.objects.all()
 
 

--- a/frontend/plan/src/actions/index.js
+++ b/frontend/plan/src/actions/index.js
@@ -144,14 +144,12 @@ export const clearSchedule = () => (
     }
 );
 
-const SEMESTER = "2019C";
-
 function buildCourseSearchUrl(searchData) {
-    return `/registrar/${SEMESTER}/courses/?search=${searchData.param}`;
+    return `/courses/?search=${searchData.param}`;
 }
 
 function buildSectionInfoSearchUrl(searchData) {
-    return `/registrar/${SEMESTER}/courses/${searchData.param}`;
+    return `/courses/${searchData.param}`;
 }
 
 

--- a/plan/search.py
+++ b/plan/search.py
@@ -1,0 +1,41 @@
+import re
+
+from rest_framework import filters
+
+
+class TypedSearchBackend(filters.SearchFilter):
+    code_re = re.compile(r'^([A-Za-z]{1,4})?[ |-]?(\d{1,5})?$')
+
+    def infer_search_type(self, query):
+        if self.code_re.match(query):
+            return 'course'
+        else:
+            return 'keyword'
+
+    @staticmethod
+    def get_search_type(request):
+        return request.GET.get('type', 'auto')
+
+    def get_search_terms(self, request):
+        search_type = self.get_search_type(request)
+        query = request.query_params.get(self.search_param, '')
+
+        match = self.code_re.match(query)
+        # If this is a course query, either by designation or by detection,
+        if (search_type == 'course' or (search_type == 'auto' and self.infer_search_type(query) == 'course')) \
+                and match and match.group(1) and match.group(2):
+            query = f'{match.group(1)}-{match.group(2)}'
+        return [query]
+
+    def get_search_fields(self, view, request):
+        search_type = self.get_search_type(request)
+
+        if search_type == 'auto':
+            search_type = self.infer_search_type(request.GET.get('search', ''))
+
+        if search_type == 'course':
+            return ['full_code']
+        elif search_type == 'keyword':
+            return ['title', 'sections__instructors__name']
+        else:
+            return super().get_search_fields(view, request)

--- a/plan/tests.py
+++ b/plan/tests.py
@@ -1,3 +1,70 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory, override_settings
+from rest_framework.test import APIClient
 
-# Create your tests here.
+from .search import TypedSearchBackend
+from courses.models import *
+from courses.util import *
+from options.models import Option
+
+TEST_SEMESTER = '2019A'
+
+
+def set_semester():
+    Option(key="SEMESTER", value=TEST_SEMESTER, value_type='TXT').save()
+
+
+class TypedSearchBackendTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.search = TypedSearchBackend()
+
+    def test_type_course(self):
+        req = self.factory.get('/', {'type': 'course', 'search': 'ABC123'})
+        terms = self.search.get_search_fields(None, req)
+        self.assertEqual(['full_code'], terms)
+
+    def test_type_keyword(self):
+        req = self.factory.get('/', {'type': 'keyword', 'search': 'ABC123'})
+        terms = self.search.get_search_fields(None, req)
+        self.assertEqual(['title', 'sections__instructors__name'], terms)
+
+    def test_auto_course(self):
+        courses = ['cis', 'CIS', 'cis120', 'anch-027', 'cis 121', 'ling-140']
+        for course in courses:
+            req = self.factory.get('/', {'type': 'auto', 'search': course})
+            terms = self.search.get_search_fields(None, req)
+            self.assertEqual(['full_code'], terms, f'search:{course}')
+
+    def test_auto_keyword(self):
+        keywords = ['rajiv', 'gandhi', 'programming', 'hello world']
+        for kw in keywords:
+            req = self.factory.get('/', {'type': 'auto', 'search': kw})
+            terms = self.search.get_search_fields(None, req)
+            self.assertEqual(['title', 'sections__instructors__name'], terms, f'search:{kw}')
+
+
+@override_settings(SWITCHBOARD_TEST_APP='pcp')
+class CourseSearchTestCase(TestCase):
+    def setUp(self):
+        self.course, self.section = get_course_and_section('CIS-120-001', TEST_SEMESTER)
+        self.math, self.math1 = get_course_and_section('MATH-114-001', TEST_SEMESTER)
+        self.client = APIClient()
+        set_semester()
+
+    def test_search_by_dept(self):
+        response = self.client.get('/courses/', {'search': 'math', 'type': 'auto'})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(len(response.data), 1)
+        course_codes = [d['id'] for d in response.data]
+        self.assertTrue('CIS-120' not in course_codes and 'MATH-114' in course_codes)
+
+    def test_search_by_instructor(self):
+        self.section.instructors.add(Instructor.objects.get_or_create(name='Tiffany Chang')[0])
+        self.math1.instructors.add(Instructor.objects.get_or_create(name='Josh Doman')[0])
+        searches = ['Tiffany', 'Chang']
+        for search in searches:
+            response = self.client.get('/courses/', {'search': search, 'type': 'auto'})
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(len(response.data), 1)
+            course_codes = [d['id'] for d in response.data]
+            self.assertTrue('CIS-120' in course_codes and 'MATH-114' not in course_codes, f'search:{search}')

--- a/plan/urls.py
+++ b/plan/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
 from . import views
-from courses.views import CourseDetail
+from courses.views import CourseDetail, RequirementList
 
 urlpatterns = [
     # omit semester parameter, since PCP only cares about the current semester.
     path('courses/', views.CourseListSearch.as_view()),
     path('courses/<slug:full_code>/', CourseDetail.as_view()),
+    path('requirements/', RequirementList.as_view()),
 ]

--- a/plan/urls.py
+++ b/plan/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+from courses.views import CourseDetail
+
+urlpatterns = [
+    # omit semester parameter, since PCP only cares about the current semester.
+    path('courses/', views.CourseListSearch.as_view()),
+    path('courses/<slug:full_code>/', CourseDetail.as_view()),
+]

--- a/plan/views.py
+++ b/plan/views.py
@@ -3,6 +3,8 @@ from django.shortcuts import render
 from courses.views import CourseList
 from .search import TypedSearchBackend
 
+from courses.models import Requirement
+
 
 class CourseListSearch(CourseList):
     filter_backends = (TypedSearchBackend, )
@@ -10,4 +12,14 @@ class CourseListSearch(CourseList):
 
     def get_queryset(self):
         queryset = super().get_queryset()
+
+        req_id = self.request.query_params.get('requirement')
+        if req_id is not None:
+            code, school = req_id.split('@')
+            try:
+                requirement = Requirement.objects.get(semester=self.get_semester(), code=code, school=school)
+            except Requirement.DoesNotExist:
+                return queryset.none()
+            queryset = queryset.filter(id__in=requirement.satisfying_courses.all())
+
         return queryset

--- a/plan/views.py
+++ b/plan/views.py
@@ -1,3 +1,13 @@
 from django.shortcuts import render
 
-# Create your views here.
+from courses.views import CourseList
+from .search import TypedSearchBackend
+
+
+class CourseListSearch(CourseList):
+    filter_backends = (TypedSearchBackend, )
+    search_fields = ('full_code', 'title', 'sections__instructors__name')
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset


### PR DESCRIPTION
This PR refactors most searching and filtering logic into the `plan` package, as it will be primarily in Penn Course Plan. Additionally, ability to filter by requirement was added, along with an index page `requirements/` to see all requirements.