### PR TITLE
Alphabetized installed-apps

### DIFF
--- a/PennCourses/settings/base.py
+++ b/PennCourses/settings/base.py
@@ -47,12 +47,12 @@ INSTALLED_APPS = [
     'rest_framework',
     'debug_toolbar',
 
+    'alert',
     'courses',
     'options',
-    'shortener',
-    'alert',
-    'review',
     'plan',
+    'review',
+    'shortener',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Apparently plan was in installed_apps but it wasn't in my local version (weird)... just alphabetized the apps to test out making a branch / pull request