### PR TITLE
Only show sections from OpenData

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -138,7 +138,10 @@ class RequirementDetailSerializer(RequirementListSerializer):
 
 class CourseListSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source='course_id')
-    # sections = MiniSectionSerializer(many=True)
+    num_sections = serializers.SerializerMethodField()
+
+    def get_num_sections(self, obj):
+        return obj.sections.count()
 
     @staticmethod
     def setup_eager_loading(queryset):
@@ -158,7 +161,7 @@ class CourseListSerializer(serializers.ModelSerializer):
             'title',
             'description',
             'semester',
-            # 'sections',
+            'num_sections',
         ]
 
 

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -1,3 +1,4 @@
+from django.db.models import Prefetch, Q
 from rest_framework import serializers
 
 from courses.models import Course, Meeting, Requirement, Section
@@ -123,6 +124,9 @@ class CourseListSerializer(serializers.ModelSerializer):
     def setup_eager_loading(queryset):
         queryset = queryset.prefetch_related('primary_listing__listing_set__department',
                                              'department',
+                                             Prefetch('sections',
+                                                      Section.objects.filter(credits__isnull=False)
+                                                      .filter(Q(status='O') | Q(status='C'))),
                                              'sections__review_set__reviewbit_set'
                                              )
         return queryset
@@ -146,6 +150,9 @@ class CourseDetailSerializer(CourseListSerializer):
     def setup_eager_loading(queryset):
         queryset = queryset.prefetch_related('primary_listing__listing_set__department',
                                              'department',
+                                             Prefetch('sections',
+                                                      Section.objects.filter(credits__isnull=False)
+                                                      .filter(Q(status='O') | Q(status='C'))),
                                              'sections__course__department',
                                              'sections__meetings__room__building',
                                              'sections__associated_sections__course__department',

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -148,8 +148,10 @@ class CourseListSerializer(serializers.ModelSerializer):
         queryset = queryset.prefetch_related('primary_listing__listing_set__department',
                                              'department',
                                              Prefetch('sections',
-                                                      Section.objects.filter(credits__isnull=False)
-                                                      .filter(Q(status='O') | Q(status='C'))),
+                                                      Section.objects
+                                                      .filter(meetings__isnull=False)
+                                                      .filter(credits__isnull=False)
+                                                      .filter(Q(status='O') | Q(status='C')).distinct()),
                                              'sections__review_set__reviewbit_set'
                                              )
         return queryset
@@ -175,8 +177,10 @@ class CourseDetailSerializer(CourseListSerializer):
         queryset = queryset.prefetch_related('primary_listing__listing_set__department',
                                              'department',
                                              Prefetch('sections',
-                                                      Section.objects.filter(credits__isnull=False)
-                                                      .filter(Q(status='O') | Q(status='C'))),
+                                                      Section.objects
+                                                      .filter(meetings__isnull=False)
+                                                      .filter(credits__isnull=False)
+                                                      .filter(Q(status='O') | Q(status='C')).distinct()),
                                              'sections__course__department',
                                              'sections__meetings__room__building',
                                              'sections__associated_sections__course__department',

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -31,6 +31,25 @@ class SectionIdField(serializers.RelatedField):
         }
 
 
+class MiniSectionSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Section
+        fields = [
+            'id',
+            'status',
+            'activity',
+        ]
+
+    @staticmethod
+    def get_semester(obj):
+        return obj.course.semester
+
+    @staticmethod
+    def setup_eager_loading(queryset):
+        return queryset
+
+
 class SectionSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source='normalized')
     semester = serializers.SerializerMethodField()
@@ -119,6 +138,7 @@ class RequirementDetailSerializer(RequirementListSerializer):
 
 class CourseListSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source='course_id')
+    # sections = MiniSectionSerializer(many=True)
 
     @staticmethod
     def setup_eager_loading(queryset):
@@ -138,6 +158,7 @@ class CourseListSerializer(serializers.ModelSerializer):
             'title',
             'description',
             'semester',
+            # 'sections',
         ]
 
 

--- a/courses/tests.py
+++ b/courses/tests.py
@@ -215,8 +215,8 @@ class CourseListTestCase(TestCase):
         self.assertEqual(len(response.data), 2)
         course_codes = [d['id'] for d in response.data]
         self.assertTrue('CIS-120' in course_codes and 'MATH-114' in course_codes)
-        self.assertTrue(1, len(response.data[0]['sections']))
-        self.assertTrue(1, len(response.data[1]['sections']))
+        self.assertTrue(1, response.data[0]['num_sections'])
+        self.assertTrue(1, response.data[1]['num_sections'])
 
     def test_semester_setting(self):
         new_sem = TEST_SEMESTER[:-1] + 'Z'
@@ -246,7 +246,7 @@ class CourseListTestCase(TestCase):
         self.math1.status = 'X'
         self.math1.save()
         response = self.client.get('/all/courses/')
-        self.assertEqual(len(response.data[1]['sections']), 0, response.data)
+        self.assertEqual(response.data[1]['num_sections'], 0, response.data)
 
 
 @override_settings(SWITCHBOARD_TEST_APP='api')

--- a/courses/tests.py
+++ b/courses/tests.py
@@ -229,6 +229,13 @@ class CourseListTestCase(TestCase):
         response = self.client.get(f'/current/courses/')
         self.assertEqual(len(response.data), 2)
 
+    def test_course_with_no_sections_not_in_list(self):
+        self.math.sections.all().delete()
+        print(self.math.sections.all())
+        print(Course.objects.filter(sections__isnull=False))
+        response = self.client.get('/all/courses/')
+        self.assertEqual(len(response.data), 1, response.data)
+
 
 @override_settings(SWITCHBOARD_TEST_APP='api')
 class SectionListTestCase(TestCase):

--- a/courses/util.py
+++ b/courses/util.py
@@ -175,3 +175,31 @@ def update_course_from_record(update):
     section = update.section
     section.status = update.new_status
     section.save()
+
+
+def create_mock_data(code, semester):
+    course, section = get_course_and_section(code, semester)
+    section.credits = 1
+    section.status = 'O'
+    section.save()
+    m = [
+        {
+            'building_code': 'LLAB',
+            'building_name': 'Leidy Laboratories of Biology',
+            'end_hour_24': 12,
+            'end_minutes': 0,
+            'end_time': '12:00 PM',
+            'end_time_24': 12.0,
+            'meeting_days': 'MWF',
+            'room_number': '10',
+            'section_id': 'CIS 120001',
+            'section_id_normalized': 'CIS -120-001',
+            'start_hour_24': 11,
+            'start_minutes': 0,
+            'start_time': '11:00 AM',
+            'start_time_24': 11.0,
+            'term': '2019C'
+        }
+    ]
+    add_meetings(section, m)
+    return course, section

--- a/courses/views.py
+++ b/courses/views.py
@@ -41,7 +41,7 @@ class SectionList(generics.ListAPIView, BaseCourseMixin):
 
 class CourseList(generics.ListAPIView, BaseCourseMixin):
     serializer_class = CourseListSerializer
-    queryset = Course.objects.all()
+    queryset = Course.objects.filter(sections__isnull=False)
 
 
 class CourseDetail(generics.RetrieveAPIView, BaseCourseMixin):

--- a/frontend/plan/src/components/selector/CourseList.js
+++ b/frontend/plan/src/components/selector/CourseList.js
@@ -14,13 +14,14 @@ export default function CourseList({ courses, getCourse }) {
             </div>
             <ul className="scrollable course-list">
                 {
-                    courses.map(course => (
-                        <Course
-                            key={course.id}
-                            course={course}
-                            onClick={() => getCourse(course.id)}
-                        />
-                    ))
+                    courses
+                        .map(course => (
+                            <Course
+                                key={course.id}
+                                course={course}
+                                onClick={() => getCourse(course.id)}
+                            />
+                        ))
                 }
             </ul>
         </div>

--- a/frontend/plan/src/components/selector/Selector.js
+++ b/frontend/plan/src/components/selector/Selector.js
@@ -48,7 +48,7 @@ Selector.propTypes = {
 
 const mapStateToProps = state => (
     {
-        courses: state.sections.searchResults,
+        courses: state.sections.searchResults.filter(course => course.sections.length > 0),
         course: state.sections.course,
     }
 );

--- a/frontend/plan/src/components/selector/Selector.js
+++ b/frontend/plan/src/components/selector/Selector.js
@@ -48,7 +48,7 @@ Selector.propTypes = {
 
 const mapStateToProps = state => (
     {
-        courses: state.sections.searchResults.filter(course => course.sections.length > 0),
+        courses: state.sections.searchResults.filter(course => course.num_sections > 0),
         course: state.sections.course,
     }
 );

--- a/plan/serializers.py
+++ b/plan/serializers.py
@@ -75,7 +75,8 @@ class CourseListWithReviewSerializer(CourseListSerializer):
             'semester',
             'course_quality',
             'instructor_quality',
-            'difficulty'
+            'difficulty',
+            'num_sections',
         ]
 
 

--- a/plan/tests.py
+++ b/plan/tests.py
@@ -2,7 +2,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from rest_framework.test import APIClient
 
 from courses.models import Instructor, Requirement
-from courses.util import get_course_and_section
+from courses.util import create_mock_data
 from options.models import Option
 from plan.search import TypedSearchBackend
 from review.models import Review
@@ -48,8 +48,8 @@ class TypedSearchBackendTestCase(TestCase):
 @override_settings(SWITCHBOARD_TEST_APP='pcp')
 class CourseSearchTestCase(TestCase):
     def setUp(self):
-        self.course, self.section = get_course_and_section('CIS-120-001', TEST_SEMESTER)
-        self.math, self.math1 = get_course_and_section('MATH-114-001', TEST_SEMESTER)
+        self.course, self.section = create_mock_data('CIS-120-001', TEST_SEMESTER)
+        self.math, self.math1 = create_mock_data('MATH-114-001', TEST_SEMESTER)
         self.client = APIClient()
         set_semester()
 
@@ -75,8 +75,8 @@ class CourseSearchTestCase(TestCase):
 @override_settings(SWITCHBOARD_TEST_APP='pcp')
 class CreditUnitFilterTestCase(TestCase):
     def setUp(self):
-        self.course, self.section = get_course_and_section('CIS-120-001', TEST_SEMESTER)
-        _, self.section2 = get_course_and_section('CIS-120-201', TEST_SEMESTER)
+        self.course, self.section = create_mock_data('CIS-120-001', TEST_SEMESTER)
+        _, self.section2 = create_mock_data('CIS-120-201', TEST_SEMESTER)
         self.section.credits = 1.0
         self.section2.credits = 0.0
         self.section.save()
@@ -98,8 +98,8 @@ class CreditUnitFilterTestCase(TestCase):
 @override_settings(SWITCHBOARD_TEST_APP='pcp')
 class RequirementFilterTestCase(TestCase):
     def setUp(self):
-        self.course, self.section = get_course_and_section('CIS-120-001', TEST_SEMESTER)
-        self.math, self.math1 = get_course_and_section('MATH-114-001', TEST_SEMESTER)
+        self.course, self.section = create_mock_data('CIS-120-001', TEST_SEMESTER)
+        self.math, self.math1 = create_mock_data('MATH-114-001', TEST_SEMESTER)
         self.req = Requirement(semester=TEST_SEMESTER, code='REQ', school='SAS')
         self.req.save()
         self.req.courses.add(self.math)
@@ -118,7 +118,7 @@ class RequirementFilterTestCase(TestCase):
         self.assertEqual('MATH-114', response.data[0]['id'])
 
     def test_multi_req(self):
-        course3, section3 = get_course_and_section('CIS-240-001', TEST_SEMESTER)
+        course3, section3 = create_mock_data('CIS-240-001', TEST_SEMESTER)
         req2 = Requirement(semester=TEST_SEMESTER, code='REQ2', school='SEAS')
         req2.save()
         req2.courses.add(course3)
@@ -130,11 +130,11 @@ class RequirementFilterTestCase(TestCase):
 @override_settings(SWITCHBOARD_TEST_APP='pcp')
 class CourseReviewAverageTestCase(TestCase):
     def setUp(self):
-        self.course, self.section = get_course_and_section('CIS-120-001', TEST_SEMESTER)
-        _, self.section2 = get_course_and_section('CIS-120-002', TEST_SEMESTER)
+        self.course, self.section = create_mock_data('CIS-120-001', TEST_SEMESTER)
+        _, self.section2 = create_mock_data('CIS-120-002', TEST_SEMESTER)
         self.instructor = Instructor(name='Person1')
         self.instructor.save()
-        self.rev1 = Review(section=get_course_and_section('CIS-120-003', '2005C')[1], instructor=self.instructor)
+        self.rev1 = Review(section=create_mock_data('CIS-120-003', '2005C')[1], instructor=self.instructor)
         self.rev1.save()
         self.rev1.set_scores({
             'course_quality': 4,
@@ -143,7 +143,7 @@ class CourseReviewAverageTestCase(TestCase):
         })
         self.instructor2 = Instructor(name='Person2')
         self.instructor2.save()
-        self.rev2 = Review(section=get_course_and_section('CIS-120-002', '2015A')[1], instructor=self.instructor2)
+        self.rev2 = Review(section=create_mock_data('CIS-120-002', '2015A')[1], instructor=self.instructor2)
         self.rev2.instructor = self.instructor2
         self.rev2.save()
         self.rev2.set_scores({

--- a/plan/views.py
+++ b/plan/views.py
@@ -1,3 +1,5 @@
+from django.db.models import Prefetch
+
 from courses.views import CourseDetail, CourseList
 from plan.filters import bound_filter, requirement_filter
 from plan.search import TypedSearchBackend
@@ -10,7 +12,7 @@ class CourseListSearch(CourseList):
     serializer_class = CourseListWithReviewSerializer
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = super().get_queryset().prefetch_related(Prefetch('sections'))
 
         filters = {
             'requirements': requirement_filter,


### PR DESCRIPTION
There's three sources of data for our database: PCR, OpenData API, and the Course Status Webhook. We only want to show courses in PCP which are 1) not cancelled and 2) we have sufficient data for. The one source of truth for number 2 is the OpenData API. This PR filters out sections which are not from OpenData (i.e. don't have a credit amount) or which the course status webhook tells us are cancelled.