### PR TITLE
Add instructor names to API

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -34,6 +34,7 @@ class SectionSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source='normalized')
     semester = serializers.SerializerMethodField()
     meetings = MeetingSerializer(many=True)
+    instructors = serializers.StringRelatedField(many=True)
 
     @staticmethod
     def get_semester(obj):
@@ -54,7 +55,8 @@ class SectionSerializer(serializers.ModelSerializer):
             'activity',
             'credits',
             'semester',
-            'meetings'
+            'meetings',
+            'instructors',
         ]
 
 
@@ -70,6 +72,7 @@ class SectionDetailSerializer(SectionSerializer):
             'credits',
             'semester',
             'meetings',
+            'instructors',
         ] + [
             'associated_sections',
         ]

--- a/courses/tests.py
+++ b/courses/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
-from courses.models import Course, Department, Requirement, Section
+from courses.models import Course, Department, Instructor, Requirement, Section
 from courses.util import (get_course, get_course_and_section, record_update,
                           separate_course_code, set_crosslistings, update_course_from_record)
 from options.models import Option
@@ -249,6 +249,9 @@ class SectionListTestCase(TestCase):
 class CourseDetailTestCase(TestCase):
     def setUp(self):
         self.course, self.section = get_course_and_section('CIS-120-001', TEST_SEMESTER)
+        i = Instructor(name='Test Instructor')
+        i.save()
+        self.section.instructors.add(i)
         self.math, self.math1 = get_course_and_section('MATH-114-001', TEST_SEMESTER)
         self.client = APIClient()
         set_semester()
@@ -259,6 +262,7 @@ class CourseDetailTestCase(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data['id'], 'CIS-120')
         self.assertEqual(len(response.data['sections']), 2)
+        self.assertEqual('Test Instructor', response.data['sections'][0]['instructors'][0])
 
     def test_not_get_course(self):
         response = self.client.get('/all/courses/CIS-160/')


### PR DESCRIPTION
Pretty self-explanatory. API responses for sections will now have an array of instructor names attached.