### PR TITLE
Collapsible requirements

### DIFF
--- a/frontend/plan/package-lock.json
+++ b/frontend/plan/package-lock.json
@@ -2780,7 +2780,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2801,12 +2802,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2821,17 +2824,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2948,7 +2954,8 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2960,6 +2967,7 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2974,6 +2982,7 @@
               "version": "3.0.4",
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2981,12 +2990,14 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "resolved": false,
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3005,6 +3016,7 @@
               "version": "0.5.1",
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3085,7 +3097,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3097,6 +3110,7 @@
               "version": "1.4.0",
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3182,7 +3196,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": false,
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3218,6 +3233,7 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3237,6 +3253,7 @@
               "version": "3.0.1",
               "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3280,12 +3297,14 @@
             "wrappy": {
               "version": "1.0.2",
               "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": false,
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+              "optional": true
             }
           }
         },
@@ -6722,7 +6741,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6743,12 +6763,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6763,17 +6785,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6890,7 +6915,8 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6902,6 +6928,7 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6916,6 +6943,7 @@
               "version": "3.0.4",
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -6923,12 +6951,14 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "resolved": false,
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6947,6 +6977,7 @@
               "version": "0.5.1",
               "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7027,7 +7058,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7039,6 +7071,7 @@
               "version": "1.4.0",
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7124,7 +7157,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": false,
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7160,6 +7194,7 @@
               "version": "1.0.2",
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7179,6 +7214,7 @@
               "version": "3.0.1",
               "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7222,12 +7258,14 @@
             "wrappy": {
               "version": "1.0.2",
               "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": false,
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+              "optional": true
             }
           }
         }

--- a/frontend/plan/src/components/selector/Tag.js
+++ b/frontend/plan/src/components/selector/Tag.js
@@ -1,13 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-export default function Tag({ children, onClick = null }) {
+export default function Tag({ children, onClick = null, isAdder = false }) {
     return (
         <span
             role="button"
             onClick={onClick}
-            className="tag is-rounded is-light detail-tag"
-            style={{ cursor: onClick ? "pointer" : "default" }}
+            className={"tag is-rounded is-light detail-tag" + (isAdder ? " is-adder" : "")}
         >
             {children}
         </span>
@@ -18,4 +17,5 @@ Tag.propTypes = {
     // eslint-disable-next-line
     children: PropTypes.any,
     onClick: PropTypes.func,
+    isAdder: PropTypes.bool,
 };

--- a/frontend/plan/src/components/selector/Tag.js
+++ b/frontend/plan/src/components/selector/Tag.js
@@ -6,7 +6,7 @@ export default function Tag({ children, onClick = null, isAdder = false }) {
         <span
             role="button"
             onClick={onClick}
-            className={"tag is-rounded is-light detail-tag" + (isAdder ? " is-adder" : "")}
+            className={`tag is-rounded is-light detail-tag${isAdder ? " is-adder" : ""}`}
         >
             {children}
         </span>

--- a/frontend/plan/src/components/selector/TagList.js
+++ b/frontend/plan/src/components/selector/TagList.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import Tag from "./Tag";
 
@@ -7,24 +7,28 @@ import "bulma-popover/css/bulma-popver.min.css";
 export default function TagList({
     elements, onClick = null, limit = 1, select = null,
 }) {
+    const [expanded, setExpanded] = useState(false);
     const visibleTags = elements.slice(0, limit);
     const hiddenTags = elements.slice(limit);
     let tagPopover = null;
+    const sign = expanded ? "-" : "+";
+    const adder = <Tag isAdder
+                       onClick={() => setExpanded(!expanded)}>{`${sign}${hiddenTags.length}`}</Tag>;
     if (hiddenTags.length > 0) {
         tagPopover = (
-            <span className="popover is-popover-left">
-                <span className="popover-trigger">
-                    <Tag>{`+${hiddenTags.length}`}</Tag>
-                </span>
-                <span className="popover-content">
+            <span>
+                {!expanded && adder}
+                <span className="taglist" style={{ height: expanded ? "auto" : 0 }}>
                     {hiddenTags.map(elt => <Tag>{elt}</Tag>)}
                 </span>
+                {expanded && adder}
             </span>
         );
     }
     return (
         <span>
-            {visibleTags.map(elt => <Tag onClick={onClick ? () => onClick(elt.replace(/ /g, "-")) : null}>{elt}</Tag>)}
+            {visibleTags.map(elt => <Tag
+                onClick={onClick ? () => onClick(elt.replace(/ /g, "-")) : null}>{elt}</Tag>)}
             {tagPopover}
         </span>
     );

--- a/frontend/plan/src/components/selector/TagList.js
+++ b/frontend/plan/src/components/selector/TagList.js
@@ -11,23 +11,25 @@ export default function TagList({
     const visibleTags = elements.slice(0, limit);
     const hiddenTags = elements.slice(limit);
     let tagPopover = null;
-    const sign = expanded ? "-" : "+";
-    const adder = (
-        <Tag
-            isAdder
-            onClick={() => setExpanded(!expanded)}
-        >
-            {`${sign}${hiddenTags.length}`}
-        </Tag>
-    );
     if (hiddenTags.length > 0) {
         tagPopover = (
             <span>
-                {!expanded && adder}
+                {!expanded && (
+                    <Tag
+                        isAdder
+                        onClick={() => setExpanded(true)}
+                    >
+                        {expanded ? "Hide requirements" : `+${hiddenTags.length}`}
+                    </Tag>
+                )}
                 <span className="taglist" style={{ height: expanded ? "auto" : 0 }}>
                     {hiddenTags.map(elt => <Tag>{elt}</Tag>)}
                 </span>
-                {expanded && adder}
+                {expanded && (
+                    <a role="button" onClick={() => setExpanded(false)}>
+                    Hide requirements
+                    </a>
+                )}
             </span>
         );
     }

--- a/frontend/plan/src/components/selector/TagList.js
+++ b/frontend/plan/src/components/selector/TagList.js
@@ -12,8 +12,14 @@ export default function TagList({
     const hiddenTags = elements.slice(limit);
     let tagPopover = null;
     const sign = expanded ? "-" : "+";
-    const adder = <Tag isAdder
-                       onClick={() => setExpanded(!expanded)}>{`${sign}${hiddenTags.length}`}</Tag>;
+    const adder = (
+        <Tag
+            isAdder
+            onClick={() => setExpanded(!expanded)}
+        >
+            {`${sign}${hiddenTags.length}`}
+        </Tag>
+    );
     if (hiddenTags.length > 0) {
         tagPopover = (
             <span>
@@ -27,8 +33,13 @@ export default function TagList({
     }
     return (
         <span>
-            {visibleTags.map(elt => <Tag
-                onClick={onClick ? () => onClick(elt.replace(/ /g, "-")) : null}>{elt}</Tag>)}
+            {visibleTags.map(elt => (
+                <Tag
+                    onClick={onClick ? () => onClick(elt.replace(/ /g, "-")) : null}
+                >
+                    {elt}
+                </Tag>
+            ))}
             {tagPopover}
         </span>
     );

--- a/frontend/plan/src/styles/selector.css
+++ b/frontend/plan/src/styles/selector.css
@@ -82,6 +82,30 @@
     font-weight: normal;
 }
 
+.taglist {
+    overflow: hidden;
+    display: inline-block;
+}
+
+.tag, .taglist * {
+    user-select: none;
+}
+
+.tag {
+    transition: 200ms ease background;
+    margin-bottom: 0.35rem;
+    margin-right: 0.35rem;
+    cursor: pointer;
+}
+
+.tag.is-adder:hover {
+    background: #9fa4a6;
+}
+
+.tag.is-adder:active {
+    background: #777b7c;
+}
+
 .pcr-svg {
     border: 2px solid #EEEEEE;
     border-radius: 4px;


### PR DESCRIPTION
Instead of having a popover for requirements, requirements can now be expanded and collapsed. The design needs to be improved before this is merged.


Collapsed (default state):
![image](https://user-images.githubusercontent.com/41085135/67527985-48445880-f686-11e9-9555-c4ff7ec158a9.png)


Expanded:
![image](https://user-images.githubusercontent.com/41085135/67527956-3c589680-f686-11e9-88cc-e1badee17504.png)

