### PR TITLE
Improved Modal UX

### DIFF
--- a/frontend/plan/src/components/modals/NameScheduleModalInterior.js
+++ b/frontend/plan/src/components/modals/NameScheduleModalInterior.js
@@ -32,7 +32,7 @@ const NameScheduleModalInterior = ({
                 value={userInput}
                 type="text"
                 ref={ref => setInputRef(ref)}
-                style={{ backgroundColor: error ? "#f9dcda" : "white" }}
+                style={{ backgroundColor: error ? "#f9dcda" : "#f1f1f1" }}
                 onChange={() => setUserInput(inputRef.value)}
                 onClick={() => {
                     if (overwriteDefault && userInput === defaultValue) {

--- a/frontend/plan/src/components/modals/NameScheduleModalInterior.js
+++ b/frontend/plan/src/components/modals/NameScheduleModalInterior.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 import { validateScheduleName } from "../schedule/schedule_name_validation";
 
 const NameScheduleModalInterior = ({
-    usedScheduleNames, namingFunction, close, buttonName,
+    usedScheduleNames, namingFunction, close, buttonName, defaultValue, overwriteDefault = false,
 }) => {
     const [inputRef, setInputRef] = useState(null);
-    const [userInput, setUserInput] = useState("");
+    const [userInput, setUserInput] = useState(defaultValue);
     const { error, message: errorMessage } = validateScheduleName(userInput, usedScheduleNames);
     const submit = () => {
         const scheduleName = inputRef.value;
@@ -18,10 +18,16 @@ const NameScheduleModalInterior = ({
     return (
         <div>
             <input
+                value={userInput}
                 type="text"
                 ref={ref => setInputRef(ref)}
                 style={{ backgroundColor: error ? "#f9dcda" : "white" }}
                 onChange={() => setUserInput(inputRef.value)}
+                onClick={() => {
+                    if (overwriteDefault && userInput === defaultValue) {
+                        setUserInput("");
+                    }
+                }}
                 onKeyUp={(e) => {
                     if (e.keyCode === 13) {
                         submit();
@@ -48,6 +54,8 @@ NameScheduleModalInterior.propTypes = {
     namingFunction: PropTypes.func,
     close: PropTypes.func,
     buttonName: PropTypes.string,
+    defaultValue: PropTypes.string,
+    overwriteDefault: PropTypes.bool,
 };
 
 export default NameScheduleModalInterior;

--- a/frontend/plan/src/components/modals/NameScheduleModalInterior.js
+++ b/frontend/plan/src/components/modals/NameScheduleModalInterior.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { validateScheduleName } from "../schedule/schedule_name_validation";
 
@@ -8,6 +8,17 @@ const NameScheduleModalInterior = ({
     const [inputRef, setInputRef] = useState(null);
     const [userInput, setUserInput] = useState(defaultValue);
     const { error, message: errorMessage } = validateScheduleName(userInput, usedScheduleNames);
+    useEffect(() => {
+        const listener = (event) => {
+            if (!userInput && inputRef && !inputRef.contains(event.target)) {
+                setUserInput(defaultValue);
+            }
+        };
+        document.addEventListener("click", listener);
+        return () => {
+            document.removeEventListener("click", listener);
+        };
+    });
     const submit = () => {
         const scheduleName = inputRef.value;
         if (!error) {

--- a/frontend/plan/src/components/schedule/Schedule.js
+++ b/frontend/plan/src/components/schedule/Schedule.js
@@ -240,7 +240,7 @@ const mapDispatchToProps = dispatch => (
                 { scheduleName: oldName, defaultValue: oldName },
                 "Rename Schedule")),
             create: () => dispatch(openModal("CREATE_SCHEDULE",
-                {defaultValue: "Schedule name", overwriteDefault: true},
+                { defaultValue: "Schedule name", overwriteDefault: true },
                 "Create Schedule")),
         },
     }

--- a/frontend/plan/src/components/schedule/Schedule.js
+++ b/frontend/plan/src/components/schedule/Schedule.js
@@ -237,10 +237,10 @@ const mapDispatchToProps = dispatch => (
             copy: scheduleName => dispatch(duplicateSchedule(scheduleName)),
             remove: scheduleName => dispatch(deleteSchedule(scheduleName)),
             rename: oldName => dispatch(openModal("RENAME_SCHEDULE",
-                { scheduleName: oldName },
+                { scheduleName: oldName, defaultValue: oldName },
                 "Rename Schedule")),
             create: () => dispatch(openModal("CREATE_SCHEDULE",
-                {},
+                {defaultValue: "Schedule name", overwriteDefault: true},
                 "Create Schedule")),
         },
     }


### PR DESCRIPTION
Changes:
- Default value for rename schedule is the old schedule name
- Default value for create schedule is "schedule name"
- Clicking out of an empty input returns it to its default value