### PR TITLE
Hotfix/sectionsmeetings

### DIFF
--- a/plan/tests.py
+++ b/plan/tests.py
@@ -242,11 +242,46 @@ class ScheduleTest(TestCase):
         self.assertEqual(len(response.data[1]['sections']), 2)
         self.assertEqual(response.data[1]['sections'][0]['id'], 'CIS-121-001')
 
+    def test_create_schedule_meetings(self):
+        response = self.client.post('/schedules/',
+                                    json.dumps({'semester': TEST_SEMESTER,
+                                                'name': 'New Test Schedule',
+                                                'meetings': [{'id': 'CIS-121-001', 'semester': TEST_SEMESTER},
+                                                             {'id': 'CIS-160-001', 'semester': TEST_SEMESTER}]}),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        response = self.client.get('/schedules/')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, len(response.data))
+        self.assertEqual(response.data[1]['name'], 'New Test Schedule')
+        self.assertEqual(len(response.data[1]['sections']), 2)
+        self.assertEqual(response.data[1]['sections'][0]['id'], 'CIS-121-001')
+
     def test_update_schedule_specific(self):
         response = self.client.put('/schedules/' + str(self.s.id) + '/',
                                    json.dumps({'semester': TEST_SEMESTER,
                                                'name': 'New Test Schedule',
                                                'sections': [{'id': 'CIS-121-001', 'semester': TEST_SEMESTER},
+                                                            {'id': 'CIS-160-001', 'semester': TEST_SEMESTER}]}),
+                                   content_type='application/json')
+        self.assertEqual(response.status_code, 202)
+        response = self.client.get('/schedules/')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.data))
+        self.assertEqual(response.data[0]['name'], 'New Test Schedule')
+        self.assertEqual(len(response.data[0]['sections']), 2)
+        self.assertEqual(response.data[0]['sections'][0]['id'], 'CIS-121-001')
+        response = self.client.get('/schedules/' + str(self.s.id) + '/')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.data['name'], 'New Test Schedule')
+        self.assertEqual(len(response.data['sections']), 2)
+        self.assertEqual(response.data['sections'][0]['id'], 'CIS-121-001')
+
+    def test_update_schedule_specific_meetings(self):
+        response = self.client.put('/schedules/' + str(self.s.id) + '/',
+                                   json.dumps({'semester': TEST_SEMESTER,
+                                               'name': 'New Test Schedule',
+                                               'meetings': [{'id': 'CIS-121-001', 'semester': TEST_SEMESTER},
                                                             {'id': 'CIS-160-001', 'semester': TEST_SEMESTER}]}),
                                    content_type='application/json')
         self.assertEqual(response.status_code, 202)

--- a/plan/views.py
+++ b/plan/views.py
@@ -66,7 +66,9 @@ class ScheduleViewSet(viewsets.ModelViewSet):
         if 'semester' not in request.data:
             request.data['semester'] = get_value('SEMESTER', None)
 
-        for s in request.data['sections']:
+        sections = get_sections(request.data)
+
+        for s in sections:
             if s.get('semester') != request.data.get('semester'):
                 return Response({'detail': 'Semester uniformity invariant violated.'},
                                 status=status.HTTP_400_BAD_REQUEST)
@@ -76,7 +78,7 @@ class ScheduleViewSet(viewsets.ModelViewSet):
             schedule.semester = request.data.get('semester')
             schedule.name = request.data.get('name')
             schedule.save()
-            schedule.sections.set(get_sections(request.data))
+            schedule.sections.set(sections)
             return Response({'message': 'success', 'id': schedule.id}, status=status.HTTP_202_ACCEPTED)
         except IntegrityError as e:
             return Response({'detail': 'IntegrityError encountered while trying to update: ' + str(e.__cause__)},
@@ -89,7 +91,9 @@ class ScheduleViewSet(viewsets.ModelViewSet):
         if 'semester' not in request.data:
             request.data['semester'] = get_value('SEMESTER', None)
 
-        for sec in request.data['sections']:
+        sections = get_sections(request.data)
+
+        for sec in sections:
             if sec.get('semester') != request.data.get('semester'):
                 return Response({'detail': 'Semester uniformity invariant violated.'},
                                 status=status.HTTP_400_BAD_REQUEST)
@@ -104,7 +108,7 @@ class ScheduleViewSet(viewsets.ModelViewSet):
                 schedule = self.get_queryset().create(person=request.user,
                                                       semester=request.data.get('semester'),
                                                       name=request.data.get('name'))
-            schedule.sections.set(get_sections(request.data))
+            schedule.sections.set(sections)
             return Response({'message': 'success', 'id': schedule.id}, status=status.HTTP_201_CREATED)
         except IntegrityError as e:
             return Response({'detail': 'IntegrityError encountered while trying to create: ' + str(e.__cause__)},

--- a/plan/views.py
+++ b/plan/views.py
@@ -69,7 +69,7 @@ class ScheduleViewSet(viewsets.ModelViewSet):
         sections = get_sections(request.data)
 
         for s in sections:
-            if s.get('semester') != request.data.get('semester'):
+            if s.course.semester != request.data.get('semester'):
                 return Response({'detail': 'Semester uniformity invariant violated.'},
                                 status=status.HTTP_400_BAD_REQUEST)
 
@@ -94,7 +94,7 @@ class ScheduleViewSet(viewsets.ModelViewSet):
         sections = get_sections(request.data)
 
         for sec in sections:
-            if sec.get('semester') != request.data.get('semester'):
+            if sec.course.semester != request.data.get('semester'):
                 return Response({'detail': 'Semester uniformity invariant violated.'},
                                 status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
This fixes a bug when you try to post using the field name 'meetings' instead of 'sections'... now the behavior is in line with what is described in the documentation.  I also tested the behavior (should have caught this earlier... clearly my testing is not exhaustive enough).