### PR TITLE
Don't create courses on submit [ch194]

### DIFF
--- a/alert/models.py
+++ b/alert/models.py
@@ -10,7 +10,7 @@ from shortener.models import Url
 
 from alert.alerts import Email, Text
 from courses.models import Section, get_current_semester
-from courses.util import get_course_and_section
+from courses.util import get_or_create_course_and_section
 
 
 class RegStatus(Enum):
@@ -132,7 +132,7 @@ class Registration(models.Model):
 def register_for_course(course_code, email_address, phone, source=SOURCE_PCA, api_key=None):
     if not email_address and not phone:
         return RegStatus.NO_CONTACT_INFO
-    course, section = get_course_and_section(course_code, get_current_semester())
+    course, section = get_or_create_course_and_section(course_code, get_current_semester())
     registration = Registration(section=section, email=email_address, phone=phone, source=source)
     registration.validate_phone()
 

--- a/alert/models.py
+++ b/alert/models.py
@@ -138,6 +138,8 @@ def register_for_course(course_code, email_address, phone, source=SOURCE_PCA, ap
         return RegStatus.COURSE_NOT_FOUND
     except Section.DoesNotExist:
         return RegStatus.COURSE_NOT_FOUND
+    except ValueError:
+        return RegStatus.COURSE_NOT_FOUND
 
     registration = Registration(section=section, email=email_address, phone=phone, source=source)
     registration.validate_phone()

--- a/alert/models.py
+++ b/alert/models.py
@@ -9,8 +9,8 @@ from django.utils import timezone
 from shortener.models import Url
 
 from alert.alerts import Email, Text
-from courses.models import Section, get_current_semester
-from courses.util import get_or_create_course_and_section
+from courses.models import Course, Section, get_current_semester
+from courses.util import get_course_and_section
 
 
 class RegStatus(Enum):
@@ -132,7 +132,13 @@ class Registration(models.Model):
 def register_for_course(course_code, email_address, phone, source=SOURCE_PCA, api_key=None):
     if not email_address and not phone:
         return RegStatus.NO_CONTACT_INFO
-    course, section = get_or_create_course_and_section(course_code, get_current_semester())
+    try:
+        course, section = get_course_and_section(course_code, get_current_semester())
+    except Course.DoesNotExist:
+        return RegStatus.COURSE_NOT_FOUND
+    except Section.DoesNotExist:
+        return RegStatus.COURSE_NOT_FOUND
+
     registration = Registration(section=section, email=email_address, phone=phone, source=source)
     registration.validate_phone()
 

--- a/alert/tasks.py
+++ b/alert/tasks.py
@@ -4,9 +4,9 @@ import redis
 from celery import shared_task
 from django.conf import settings
 
-from alert.models import Registration, get_or_create_course_and_section
+from alert.models import Registration
 from courses.models import StatusUpdate
-from courses.util import update_course_from_record
+from courses.util import update_course_from_record, get_course_and_section
 from options.models import get_value
 
 
@@ -45,7 +45,7 @@ def send_alert(reg_id, sent_by=''):
 
 
 def get_active_registrations(course_code, semester):
-    _, section = get_or_create_course_and_section(course_code, semester)
+    _, section = get_course_and_section(course_code, semester)
     return list(section.registration_set.filter(notification_sent=False))
 
 

--- a/alert/tasks.py
+++ b/alert/tasks.py
@@ -4,7 +4,7 @@ import redis
 from celery import shared_task
 from django.conf import settings
 
-from alert.models import Registration, get_course_and_section
+from alert.models import Registration, get_or_create_course_and_section
 from courses.models import StatusUpdate
 from courses.util import update_course_from_record
 from options.models import get_value
@@ -45,7 +45,7 @@ def send_alert(reg_id, sent_by=''):
 
 
 def get_active_registrations(course_code, semester):
-    _, section = get_course_and_section(course_code, semester)
+    _, section = get_or_create_course_and_section(course_code, semester)
     return list(section.registration_set.filter(notification_sent=False))
 
 

--- a/alert/tasks.py
+++ b/alert/tasks.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from alert.models import Registration
 from courses.models import StatusUpdate
-from courses.util import update_course_from_record, get_course_and_section
+from courses.util import get_course_and_section, update_course_from_record
 from options.models import get_value
 
 

--- a/alert/tests.py
+++ b/alert/tests.py
@@ -118,6 +118,11 @@ class RegisterTestCase(TestCase):
         self.assertEqual(RegStatus.COURSE_NOT_FOUND, res)
         self.assertEqual(0, Registration.objects.count())
 
+    def test_invalid_course(self):
+        res = register_for_course('econ 0-0-1', 'e@example.com', '+15555555555')
+        self.assertEqual(RegStatus.COURSE_NOT_FOUND, res)
+        self.assertEqual(0, Registration.objects.count())
+
     def test_justphone(self):
         res = register_for_course(self.sections[0].normalized, None, '5555555555')
         self.assertEqual(RegStatus.SUCCESS, res)

--- a/alert/tests.py
+++ b/alert/tests.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from alert import tasks
 from alert.models import SOURCE_API, SOURCE_PCA, Registration, RegStatus, register_for_course
 from courses.models import PCA_REGISTRATION, APIKey, APIPrivilege, Course, StatusUpdate
-from courses.util import record_update, update_course_from_record, get_or_create_course_and_section
+from courses.util import get_or_create_course_and_section, record_update, update_course_from_record
 from options.models import Option
 
 

--- a/alert/tests.py
+++ b/alert/tests.py
@@ -6,9 +6,9 @@ from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from alert import tasks
-from alert.models import SOURCE_API, SOURCE_PCA, Registration, RegStatus, get_or_create_course_and_section, register_for_course
+from alert.models import SOURCE_API, SOURCE_PCA, Registration, RegStatus, register_for_course
 from courses.models import PCA_REGISTRATION, APIKey, APIPrivilege, Course, StatusUpdate
-from courses.util import record_update, update_course_from_record
+from courses.util import record_update, update_course_from_record, get_or_create_course_and_section
 from options.models import Option
 
 
@@ -112,6 +112,11 @@ class RegisterTestCase(TestCase):
         res = register_for_course(self.sections[0].normalized, 'e@example.com', None)
         self.assertEqual(RegStatus.SUCCESS, res)
         self.assertEqual(1, len(Registration.objects.all()))
+
+    def test_phony_course(self):
+        res = register_for_course('PHONY-100-001', 'e@example.com', '+15555555555')
+        self.assertEqual(RegStatus.COURSE_NOT_FOUND, res)
+        self.assertEqual(0, Registration.objects.count())
 
     def test_justphone(self):
         res = register_for_course(self.sections[0].normalized, None, '5555555555')

--- a/alert/views.py
+++ b/alert/views.py
@@ -54,6 +54,10 @@ def do_register(course_code, email_address, phone, source, make_response, api_ke
     elif res == RegStatus.OPEN_REG_EXISTS:
         return make_response('warning',
                              "You've already registered to get alerts for %s!" % course_code)
+    elif res == RegStatus.COURSE_NOT_FOUND:
+        return make_response('danger',
+                             'The course you entered (%s) did not match any in our database. Please try again.'
+                             % course_code)
     elif res == RegStatus.NO_CONTACT_INFO:
         return make_response('danger',
                              'Please enter either a phone number or an email address.')

--- a/alert/views.py
+++ b/alert/views.py
@@ -56,7 +56,7 @@ def do_register(course_code, email_address, phone, source, make_response, api_ke
                              "You've already registered to get alerts for %s!" % course_code)
     elif res == RegStatus.COURSE_NOT_FOUND:
         return make_response('danger',
-                             '%s did not match any in our database. Please try again!' % course_code)
+                             '%s did not match any course in our database. Please try again!' % course_code)
     elif res == RegStatus.NO_CONTACT_INFO:
         return make_response('danger',
                              'Please enter either a phone number or an email address.')

--- a/alert/views.py
+++ b/alert/views.py
@@ -56,7 +56,7 @@ def do_register(course_code, email_address, phone, source, make_response, api_ke
                              "You've already registered to get alerts for %s!" % course_code)
     elif res == RegStatus.COURSE_NOT_FOUND:
         return make_response('danger',
-                             'The course you entered (%s) did not match any in our database. Please try again.'
+                             'The course you entered (%s) did not match any in our database. Please try again!'
                              % course_code)
     elif res == RegStatus.NO_CONTACT_INFO:
         return make_response('danger',

--- a/alert/views.py
+++ b/alert/views.py
@@ -56,8 +56,7 @@ def do_register(course_code, email_address, phone, source, make_response, api_ke
                              "You've already registered to get alerts for %s!" % course_code)
     elif res == RegStatus.COURSE_NOT_FOUND:
         return make_response('danger',
-                             'The course you entered (%s) did not match any in our database. Please try again!'
-                             % course_code)
+                             '%s did not match any in our database. Please try again!' % course_code)
     elif res == RegStatus.NO_CONTACT_INFO:
         return make_response('danger',
                              'Please enter either a phone number or an email address.')

--- a/courses/tests.py
+++ b/courses/tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
 from courses.models import Course, Department, Instructor, Meeting, Requirement, Section
-from courses.util import (create_mock_data, get_course, get_course_and_section, record_update,
+from courses.util import (create_mock_data, get_or_create_course, get_or_create_course_and_section, record_update,
                           relocate_reqs_from_restrictions, separate_course_code, set_crosslistings,
                           update_course_from_record, upsert_course_from_opendata)
 from options.models import Option
@@ -55,7 +55,7 @@ class GetCourseSectionTest(TestCase):
         self.s.save()
 
     def assertCourseSame(self, s):
-        course, section = get_course_and_section(s, TEST_SEMESTER)
+        course, section = get_or_create_course_and_section(s, TEST_SEMESTER)
         self.assertEqual(course, self.c, s)
         self.assertEqual(section, self.s, s)
 
@@ -73,7 +73,7 @@ class GetCourseSectionTest(TestCase):
             self.assertCourseSame(test)
 
     def test_create_course(self):
-        course, section = get_course_and_section('CIS 120 001', TEST_SEMESTER)
+        course, section = get_or_create_course_and_section('CIS 120 001', TEST_SEMESTER)
         self.assertEqual('CIS-120-001', section.full_code)
         self.assertEqual(Course.objects.count(), 2)
         self.assertEqual(course.department.code, 'CIS')
@@ -136,9 +136,9 @@ class CrosslistingTestCase(TestCase):
 class RequirementTestCase(TestCase):
     def setUp(self):
         set_semester()
-        get_course('CIS', '120', '2012A')  # dummy course to make sure we're filtering by semester
-        self.course = get_course('CIS', '120', TEST_SEMESTER)
-        self.course2 = get_course('CIS', '125', TEST_SEMESTER)
+        get_or_create_course('CIS', '120', '2012A')  # dummy course to make sure we're filtering by semester
+        self.course = get_or_create_course('CIS', '120', TEST_SEMESTER)
+        self.course2 = get_or_create_course('CIS', '125', TEST_SEMESTER)
         self.department = Department.objects.get(code='CIS')
 
         self.req1 = Requirement(semester=TEST_SEMESTER,
@@ -181,7 +181,7 @@ class RequirementTestCase(TestCase):
 
     def test_satisfying_courses(self):
         # make it so req1 has one department-level requirement, one course-level one, and one override.
-        c1 = get_course('MEAM', '101', TEST_SEMESTER)
+        c1 = get_or_create_course('MEAM', '101', TEST_SEMESTER)
         self.req1.courses.add(c1)
         courses = self.req1.satisfying_courses.all()
         self.assertEqual(2, len(courses))

--- a/courses/util.py
+++ b/courses/util.py
@@ -43,6 +43,16 @@ def get_or_create_course_and_section(course_code, semester, section_manager=None
     return course, section
 
 
+def get_course_and_section(course_code, semester, section_manager=None):
+    if section_manager is None:
+        section_manager = Section.objects
+
+    dept_code, course_id, section_id = separate_course_code(course_code)
+    course = Course.objects.get(department__code=dept_code, code=course_id, semester=semester)
+    section = section_manager.get(course=course, code=section_id)
+    return course, section
+
+
 def record_update(section_id, semester, old_status, new_status, alerted, req):
     _, section = get_or_create_course_and_section(section_id, semester)
     u = StatusUpdate(section=section,

--- a/courses/util.py
+++ b/courses/util.py
@@ -21,7 +21,7 @@ def separate_course_code(course_code):
     raise ValueError(f'Course code could not be parsed: {course_code}')
 
 
-def get_course(dept_code, course_id, semester):
+def get_or_create_course(dept_code, course_id, semester):
     dept, _ = Department.objects.get_or_create(code=dept_code)
 
     course, _ = Course.objects.get_or_create(department=dept,
@@ -31,12 +31,12 @@ def get_course(dept_code, course_id, semester):
     return course
 
 
-def get_course_and_section(course_code, semester, section_manager=None):
+def get_or_create_course_and_section(course_code, semester, section_manager=None):
     if section_manager is None:
         section_manager = Section.objects
     dept_code, course_id, section_id = separate_course_code(course_code)
 
-    course = get_course(dept_code, course_id, semester)
+    course = get_or_create_course(dept_code, course_id, semester)
 
     section, _ = section_manager.get_or_create(course=course, code=section_id)
 
@@ -44,7 +44,7 @@ def get_course_and_section(course_code, semester, section_manager=None):
 
 
 def record_update(section_id, semester, old_status, new_status, alerted, req):
-    _, section = get_course_and_section(section_id, semester)
+    _, section = get_or_create_course_and_section(section_id, semester)
     u = StatusUpdate(section=section,
                      old_status=old_status,
                      new_status=new_status,
@@ -90,7 +90,7 @@ def add_associated_sections(section, info):
         sections = info.get(assoc, [])
         for sect in sections:
             section_code = f"{sect['subject']}-{sect['course_id']}-{sect['section_id']}"
-            _, associated = get_course_and_section(section_code, semester)
+            _, associated = get_or_create_course_and_section(section_code, semester)
             section.associated_sections.add(associated)
 
 
@@ -98,7 +98,7 @@ def set_crosslistings(course, crosslist_primary):
     if len(crosslist_primary) == 0:
         course.primary_listing = course
     else:
-        primary_course, _ = get_course_and_section(crosslist_primary, course.semester)
+        primary_course, _ = get_or_create_course_and_section(crosslist_primary, course.semester)
         course.primary_listing = primary_course
 
 
@@ -147,7 +147,7 @@ def relocate_reqs_from_restrictions(rests, reqs, travellers):
 def upsert_course_from_opendata(info, semester):
     course_code = info['section_id_normalized']
     try:
-        course, section = get_course_and_section(course_code, semester)
+        course, section = get_or_create_course_and_section(course_code, semester)
     except ValueError:
         return  # if we can't parse the course code, skip this course.
 
@@ -195,7 +195,7 @@ def update_course_from_record(update):
 
 
 def create_mock_data(code, semester):
-    course, section = get_course_and_section(code, semester)
+    course, section = get_or_create_course_and_section(code, semester)
     section.credits = 1
     section.status = 'O'
     section.save()

--- a/plan/views.py
+++ b/plan/views.py
@@ -42,12 +42,16 @@ def get_sections(data):
     if 'meetings' in data:
         sections = []
         for s in data.get('meetings'):
-            _, section = get_or_create_course_and_section(s.get('id'), s.get('semester'), section_manager=Section.with_reviews)
+            _, section = get_or_create_course_and_section(s.get('id'),
+                                                          s.get('semester'),
+                                                          section_manager=Section.with_reviews)
             sections.append(section)
     elif 'sections' in data:
         sections = []
         for s in data.get('sections'):
-            _, section = get_or_create_course_and_section(s.get('id'), s.get('semester'), section_manager=Section.with_reviews)
+            _, section = get_or_create_course_and_section(s.get('id'),
+                                                          s.get('semester'),
+                                                          section_manager=Section.with_reviews)
             sections.append(section)
     return sections
 

--- a/plan/views.py
+++ b/plan/views.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from courses.models import Section
-from courses.util import get_course_and_section
+from courses.util import get_or_create_course_and_section
 from courses.views import CourseList
 from options.models import get_value
 from plan.filters import bound_filter, choice_filter, requirement_filter
@@ -42,12 +42,12 @@ def get_sections(data):
     if 'meetings' in data:
         sections = []
         for s in data.get('meetings'):
-            _, section = get_course_and_section(s.get('id'), s.get('semester'), section_manager=Section.with_reviews)
+            _, section = get_or_create_course_and_section(s.get('id'), s.get('semester'), section_manager=Section.with_reviews)
             sections.append(section)
     elif 'sections' in data:
         sections = []
         for s in data.get('sections'):
-            _, section = get_course_and_section(s.get('id'), s.get('semester'), section_manager=Section.with_reviews)
+            _, section = get_or_create_course_and_section(s.get('id'), s.get('semester'), section_manager=Section.with_reviews)
             sections.append(section)
     return sections
 

--- a/review/import_reviews.py
+++ b/review/import_reviews.py
@@ -6,7 +6,7 @@ import requests
 from django.conf import settings
 
 from courses.models import Instructor
-from courses.util import get_course_and_section
+from courses.util import get_or_create_course_and_section
 from review.models import Review
 
 
@@ -39,7 +39,7 @@ def save_reviews(revs, print_every=20):
             instr = Instructor.objects.get(name__icontains=rev['instructor'])
         else:
             instr = Instructor.objects.create(name=rev['instructor'].title())
-        _, sec = get_course_and_section(rev['section'], rev['semester'])
+        _, sec = get_or_create_course_and_section(rev['section'], rev['semester'])
         sec.instructors.add(instr)
         review, _ = Review.objects.get_or_create(instructor=instr,
                                                  section=sec)

--- a/review/tests.py
+++ b/review/tests.py
@@ -10,7 +10,8 @@ class ReviewTestCase(TestCase):
     def setUp(self):
         self.instructor = Instructor(name='Teacher')
         self.instructor.save()
-        self.review = Review(section=get_or_create_course_and_section('CIS-120-001', '2017A')[1], instructor=self.instructor)
+        self.review = Review(section=get_or_create_course_and_section('CIS-120-001', '2017A')[1],
+                             instructor=self.instructor)
         self.review.save()
 
     def test_set_bits(self):

--- a/review/tests.py
+++ b/review/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from courses.models import Instructor
-from courses.util import get_course_and_section
+from courses.util import get_or_create_course_and_section
 
 from .models import Review, ReviewBit
 
@@ -10,7 +10,7 @@ class ReviewTestCase(TestCase):
     def setUp(self):
         self.instructor = Instructor(name='Teacher')
         self.instructor.save()
-        self.review = Review(section=get_course_and_section('CIS-120-001', '2017A')[1], instructor=self.instructor)
+        self.review = Review(section=get_or_create_course_and_section('CIS-120-001', '2017A')[1], instructor=self.instructor)
         self.review.save()
 
     def test_set_bits(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-exclude = .venv, migrations, settings, manage.py, shortener, options
+exclude = .venv, migrations, settings, manage.py, shortener, options, frontend
 inline-quotes = single
 
 [isort]
@@ -12,5 +12,5 @@ lines_after_imports = 2
 multi_line_output = 0
 
 [coverage:run]
-omit = */tests/*, */tests.py, */migrations/*, */settings/*, */wsgi.py, */shortener/*, */.venv/*, manage.py, */apps.py
+omit = */tests/*, */tests.py, */migrations/*, */settings/*, */wsgi.py, */shortener/*, */.venv/*, manage.py, */apps.py, frontend/*
 source = .


### PR DESCRIPTION
This PR fixes a bug where users were able to add a registration for any course code that fit the regex, whether or not it was actually present in the list of possible courses.