### PR TITLE
PCA search to ignore delimiter choice

### DIFF
--- a/courses/tests.py
+++ b/courses/tests.py
@@ -422,3 +422,46 @@ class ParseOpendataResponseTestCase(TestCase):
         self.assertEqual(21, Section.objects.count())
         self.assertEqual(3, Meeting.objects.count())
         self.assertEqual(2, Instructor.objects.count())
+
+
+@override_settings(SWITCHBOARD_TEST_APP='pca')
+class SectionSearchTestCase(TestCase):
+    def setUp(self):
+        create_mock_data('CIS-120-001', TEST_SEMESTER)
+        create_mock_data('CIS-160-001', TEST_SEMESTER)
+        create_mock_data('CIS-120-201', TEST_SEMESTER)
+        create_mock_data('PSCI-181-001', TEST_SEMESTER)
+        self.client = APIClient()
+
+    def test_match_exact(self):
+        res = self.client.get('/courses/', {'search': 'CIS-120-001'})
+        self.assertEqual(1, len(res.data))
+        self.assertEqual('CIS-120-001', res.data[0]['section_id'])
+
+    def test_match_exact_spaces(self):
+        res = self.client.get('/courses/', {'search': 'CIS 120 001'})
+        self.assertEqual(1, len(res.data))
+        self.assertEqual('CIS-120-001', res.data[0]['section_id'])
+
+    def test_match_exact_nosep(self):
+        res = self.client.get('/courses/', {'search': 'PSCI181001'})
+        self.assertEqual(1, len(res.data))
+        self.assertEqual('PSCI-181-001', res.data[0]['section_id'])
+
+    def test_match_full_course_nosep(self):
+        res = self.client.get('/courses/', {'search': 'CIS120'})
+        self.assertEqual(2, len(res.data))
+        self.assertEqual('CIS-120-001', res.data[0]['section_id'])
+
+    def test_match_full_course_exact(self):
+        res = self.client.get('/courses/', {'search': 'CIS-120'})
+        self.assertEqual(2, len(res.data))
+        self.assertEqual('CIS-120-001', res.data[0]['section_id'])
+
+    def test_match_full_course_space(self):
+        res = self.client.get('/courses/', {'search': 'PSCI 181'})
+        self.assertEqual(1, len(res.data))
+
+    def test_match_department(self):
+        res = self.client.get('/courses/', {'search': 'CIS'})
+        self.assertEqual(3, len(res.data))

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,9 +1,10 @@
-from rest_framework import filters, generics
+from rest_framework import generics
 
 from courses.models import Course, Requirement, Section
 from courses.serializers import (CourseDetailSerializer, CourseListSerializer,
                                  MiniSectionSerializer, RequirementListSerializer)
 from options.models import get_value
+from plan.search import TypedSectionSearchBackend
 
 
 class BaseCourseMixin(generics.GenericAPIView):
@@ -32,7 +33,7 @@ class BaseCourseMixin(generics.GenericAPIView):
 class SectionList(generics.ListAPIView, BaseCourseMixin):
     serializer_class = MiniSectionSerializer
     queryset = Section.with_reviews.all()
-    filter_backends = [filters.SearchFilter]
+    filter_backends = [TypedSectionSearchBackend]
     search_fields = ['^full_code']
 
     @staticmethod

--- a/plan/tests.py
+++ b/plan/tests.py
@@ -8,7 +8,7 @@ from courses.models import Instructor, Requirement
 from courses.util import create_mock_data
 from options.models import Option
 from plan.models import Schedule
-from plan.search import TypedSearchBackend
+from plan.search import TypedCourseSearchBackend
 from review.models import Review
 
 
@@ -22,12 +22,12 @@ def set_semester():
 class TypedSearchBackendTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
-        self.search = TypedSearchBackend()
+        self.search = TypedCourseSearchBackend()
 
     def test_type_course(self):
         req = self.factory.get('/', {'type': 'course', 'search': 'ABC123'})
         terms = self.search.get_search_fields(None, req)
-        self.assertEqual(['full_code'], terms)
+        self.assertEqual(['^full_code'], terms)
 
     def test_type_keyword(self):
         req = self.factory.get('/', {'type': 'keyword', 'search': 'ABC123'})
@@ -39,7 +39,7 @@ class TypedSearchBackendTestCase(TestCase):
         for course in courses:
             req = self.factory.get('/', {'type': 'auto', 'search': course})
             terms = self.search.get_search_fields(None, req)
-            self.assertEqual(['full_code'], terms, f'search:{course}')
+            self.assertEqual(['^full_code'], terms, f'search:{course}')
 
     def test_auto_keyword(self):
         keywords = ['rajiv', 'gandhi', 'programming', 'hello world']

--- a/plan/views.py
+++ b/plan/views.py
@@ -10,12 +10,12 @@ from courses.views import CourseList
 from options.models import get_value
 from plan.filters import bound_filter, choice_filter, requirement_filter
 from plan.models import Schedule
-from plan.search import TypedSearchBackend
+from plan.search import TypedCourseSearchBackend
 from plan.serializers import ScheduleSerializer
 
 
 class CourseListSearch(CourseList):
-    filter_backends = [TypedSearchBackend]
+    filter_backends = [TypedCourseSearchBackend]
     search_fields = ('full_code', 'title', 'sections__instructors__name')
 
     def get_queryset(self):


### PR DESCRIPTION
This PR fixes PCA search so that whether you type `CIS120`, `CIS 120` or `CIS-120`, you'll get the same results since it'll all be transformed into `CIS-120` on the backend.