### PR TITLE
fix searching schedules in admin

### DIFF
--- a/plan/admin.py
+++ b/plan/admin.py
@@ -4,7 +4,7 @@ from plan.models import Schedule
 
 
 class ScheduleAdmin(admin.ModelAdmin):
-    search_fields = ('person', )
+    search_fields = ('person__username', )
     autocomplete_fields = ('person', 'sections')
 
 


### PR DESCRIPTION
Need to query a field on the relation instead of the relation itself in `search_fields`