### PR TITLE
hotfix for alert showing nonexistent classes that have status updates

### DIFF
--- a/backend/courses/views.py
+++ b/backend/courses/views.py
@@ -62,7 +62,7 @@ class SectionList(generics.ListAPIView, BaseCourseMixin):
     )
 
     serializer_class = MiniSectionSerializer
-    queryset = Section.with_reviews.all()
+    queryset = Section.with_reviews.all().exclude(activity="")
     filter_backends = [TypedSectionSearchBackend]
     search_fields = ["^full_code"]
 

--- a/backend/tests/courses/test_api.py
+++ b/backend/tests/courses/test_api.py
@@ -226,3 +226,24 @@ class DocumentationTestCase(TestCase):
     def test_no_error(self):
         response = self.client.get(reverse("openapi-schema"))
         self.assertEqual(response.status_code, 200)
+
+
+class SectionListTestCase(TestCase):
+    def setUp(self):
+        self.course, self.section = create_mock_data("CIS-120-001", TEST_SEMESTER)
+        self.math, self.math1 = create_mock_data("MATH-114-001", TEST_SEMESTER)
+        self.client = APIClient()
+        set_semester()
+
+    def test_sections_appear(self):
+        response = self.client.get(reverse("section-search"), kwargs={"semester": TEST_SEMESTER})
+        course_codes = [d["section_id"] for d in response.data]
+        self.assertTrue("CIS-120-001" in course_codes and "MATH-114-001" in course_codes)
+        self.assertEqual(2, len(response.data))
+
+    def test_section_without_(self):
+        self.math1.activity = ""
+        self.math1.save()
+        response = self.client.get(reverse("section-search"), kwargs={"semester": TEST_SEMESTER})
+        self.assertEqual(1, len(response.data))
+        self.assertEqual("CIS-120-001", response.data[0]["section_id"])


### PR DESCRIPTION
A longer term solution would be adding a field on sections and courses that explicitly has the date when the course was last included in a registrar scrape. We'd then filter to make sure that field was not null, or sufficiently new, before displaying it to the user as a course. This would effectively hide *only* courses that were in status updates but not on PIT.