### PR TITLE
Fix unwanted behavior of toggling cart item when clicking on trash/info

### DIFF
--- a/frontend/plan/components/Cart.tsx
+++ b/frontend/plan/components/Cart.tsx
@@ -102,9 +102,14 @@ const Cart = ({
                             lastAdded={lastAdded && code === lastAdded.id}
                             checked={checked}
                             meetings={meetings ? meetings : []}
-                            remove={() => removeItem(code)}
+                            remove={(event) => {
+                                event.stopPropagation();
+                                removeItem(code);
+
+                            }}
                             overlaps={overlaps}
-                            courseInfo={() => {
+                            courseInfo={(event) => {
+                                event.stopPropagation();
                                 const codeParts = code.split("-");
                                 if (!courseInfoLoading) {
                                     courseInfo(
@@ -135,12 +140,12 @@ const mapStateToProps = ({
         ),
         overlaps: course.meetings
             ? meetingSetsIntersect(
-                  course.meetings,
-                  schedules[scheduleSelected].meetings
-                      .filter((s: Section) => s.id !== course.id)
-                      .map((s: Section) => s.meetings)
-                      .flat()
-              )
+                course.meetings,
+                schedules[scheduleSelected].meetings
+                    .filter((s: Section) => s.id !== course.id)
+                    .map((s: Section) => s.meetings)
+                    .flat()
+            )
             : false,
     })),
     lastAdded,

--- a/frontend/plan/components/CartSection.tsx
+++ b/frontend/plan/components/CartSection.tsx
@@ -67,9 +67,8 @@ const CourseCheckbox = ({ checked }: CourseCheckboxProps) => {
             }}
         >
             <i
-                className={`${
-                    checked ? "fas fa-check-square" : "far fa-square"
-                }`}
+                className={`${checked ? "fas fa-check-square" : "far fa-square"
+                    }`}
                 style={checkStyle}
             />
         </div>
@@ -97,7 +96,7 @@ const CartCourseButton = styled.div`
 `;
 
 interface CourseInfoButtonProps {
-    courseInfo: () => void;
+    courseInfo: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const CourseInfoButton = ({ courseInfo }: CourseInfoButtonProps) => (
@@ -107,7 +106,7 @@ const CourseInfoButton = ({ courseInfo }: CourseInfoButtonProps) => (
 );
 
 interface CourseTrashCanProps {
-    remove: () => void;
+    remove: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const CourseTrashCan = ({ remove }: CourseTrashCanProps) => (
@@ -122,8 +121,8 @@ interface CartSectionProps {
     checked: boolean;
     overlaps: boolean;
     toggleCheck: () => void;
-    remove: () => void;
-    courseInfo: () => void;
+    remove: (event: React.MouseEvent<HTMLDivElement>) => void;
+    courseInfo: (event: React.MouseEvent<HTMLDivElement>) => void;
     lastAdded: boolean;
 }
 
@@ -172,17 +171,7 @@ const CartSection = ({
         aria-checked="false"
         lastAdded={lastAdded}
         isMobile={isMobile}
-        onClick={(e) => {
-            // ensure that it's not the trash can or info button being clicked
-            if (
-                // NOTE: explicit typecase and not null assertion operator used
-                (e.target as HTMLElement).parentElement!.getAttribute(
-                    "class"
-                ) !== "CartSection__CartCourseButton-sc-1yc7t2z-1 iJfWAl"
-            ) {
-                toggleCheck();
-            }
-        }}
+        onClick={toggleCheck}
     >
         <CourseCheckbox checked={checked} />
         <CourseDetails meetings={meetings} code={code} overlaps={overlaps} />


### PR DESCRIPTION
Previously, there was a hack that prevents the cart item to be toggled when the trash/info icons are clicked, but styled-components generates unstable class names, so the hack only works in dev. 

Opted for using `event.stopPropagation()` which is nicer anyways.