### PR TITLE
Deduplicate Status Updates, Auto-Disable PCA after Add/Drop

### DIFF
--- a/backend/alert/management/commands/recomputestats.py
+++ b/backend/alert/management/commands/recomputestats.py
@@ -96,6 +96,7 @@ def deduplicate_status_updates(semesters=None, verbose=False, semesters_precompu
             if verbose:
                 print(f"\nProcessing semester {semester}, " f"{(semester_num+1)}/{len(semesters)}.")
 
+            num_removed = 0
             for section_id in iterator_wrapper(
                 Section.objects.filter(course__semester=semester).values_list("id", flat=True)
             ):
@@ -114,7 +115,11 @@ def deduplicate_status_updates(semesters=None, verbose=False, semesters_precompu
                         continue
                     last_update = update
 
+                num_removed += len(ids_to_remove)
                 StatusUpdate.objects.filter(id__in=ids_to_remove).delete()
+            print(
+                f"Removed {num_removed} duplicate status update objects from semester {semester}."
+            )
 
     if verbose:
         print(f"Finished deduplicating status updates for semesters {str(semesters)}.")

--- a/backend/alert/management/commands/recomputestats.py
+++ b/backend/alert/management/commands/recomputestats.py
@@ -61,6 +61,65 @@ def get_semesters(semesters=None, verbose=False):
     return semesters
 
 
+def deduplicate_status_updates(semesters=None, verbose=False, semesters_precomputed=False):
+    """
+    Removes duplicate/redundant status updates from the specified semesters.
+    Args:
+        semesters: The semesters argument should be a comma-separated list of string semesters
+            corresponding to the semesters for which you want to remove duplicate/redundant
+            status updates, i.e. "2019C,2020A,2020C" for fall 2019, spring 2020, and fall 2020.
+            It defaults to None, in which case only the current semester is used. If you supply
+            the string "all", it will deduplicate for all semesters found in Courses in the db.
+            If semesters_precomputed is set to True (non-default), then this argument should
+            instead be a list of single string semesters.
+        semesters_precomputed: If False (default), the semesters argument will expect a raw
+            comma-separated string input. If True, the semesters argument will expect a list of
+            individual string semesters.
+        verbose: Set to True if you want this script to print its status as it goes,
+            or keep as False (default) if you want the script to work silently.
+    """
+
+    semesters = (
+        semesters if semesters_precomputed else get_semesters(semesters=semesters, verbose=verbose)
+    )
+
+    if verbose:
+        print(f"Deduplicating status updates for semesters {str(semesters)}...")
+
+    iterator_wrapper = tqdm if verbose else (lambda x: x)
+
+    for semester_num, semester in enumerate(semesters):
+        with transaction.atomic():
+            # We make this command an atomic transaction, so that the database will not
+            # be modified unless the entire update for a semester succeeds.
+
+            if verbose:
+                print(f"\nProcessing semester {semester}, " f"{(semester_num+1)}/{len(semesters)}.")
+
+            for section_id in iterator_wrapper(
+                Section.objects.filter(course__semester=semester).values_list("id", flat=True)
+            ):
+                last_update = None
+                ids_to_remove = []  # IDs of redundant status updates to remove
+
+                for update in StatusUpdate.objects.filter(section_id=section_id).order_by(
+                    "created_at"
+                ):
+                    if (
+                        last_update
+                        and last_update.old_status == update.old_status
+                        and last_update.new_status == update.new_status
+                    ):
+                        ids_to_remove.append(update.id)
+                        continue
+                    last_update = update
+
+                StatusUpdate.objects.filter(id__in=ids_to_remove).delete()
+
+    if verbose:
+        print(f"Finished deduplicating status updates for semesters {str(semesters)}.")
+
+
 def recompute_percent_open(semesters=None, verbose=False, semesters_precomputed=False):
     """
     Recomputes the percent_open field for each section in the given semester(s).
@@ -445,12 +504,14 @@ def recompute_demand_distribution_estimates(
 def recompute_stats(semesters=None, semesters_precomputed=False, verbose=False):
     """
     Recomputes PCA demand distribution estimates, as well as the registration_volume
-    and percent_open fields for all sections in the given semester(s).
+    and percent_open fields for all sections in the given semester(s). Deduplicates 
+    status updates saved to the database.
     """
     if not semesters_precomputed:
         semesters = get_semesters(semesters=semesters, verbose=verbose)
     semesters = fill_in_add_drop_periods(verbose=True).intersection(semesters)
     load_add_drop_dates(verbose=True)
+    deduplicate_status_updates(verbose=True)
     recompute_demand_distribution_estimates(
         semesters=semesters, semesters_precomputed=True, verbose=verbose
     )

--- a/backend/alert/management/commands/recomputestats.py
+++ b/backend/alert/management/commands/recomputestats.py
@@ -504,7 +504,7 @@ def recompute_demand_distribution_estimates(
 def recompute_stats(semesters=None, semesters_precomputed=False, verbose=False):
     """
     Recomputes PCA demand distribution estimates, as well as the registration_volume
-    and percent_open fields for all sections in the given semester(s). Deduplicates 
+    and percent_open fields for all sections in the given semester(s). Deduplicates
     status updates saved to the database.
     """
     if not semesters_precomputed:

--- a/backend/alert/management/commands/webhookbackup.py
+++ b/backend/alert/management/commands/webhookbackup.py
@@ -1,9 +1,9 @@
 import logging
 
 from django.core.management.base import BaseCommand
-from options.models import get_bool
 from tqdm import tqdm
 
+from alert.util import should_send_pca_alert
 from alert.views import alert_for_course
 from courses import registrar
 from courses.util import get_current_semester
@@ -50,13 +50,7 @@ class Command(BaseCommand):
                 stats["missing_data"] += 1
                 continue
 
-            should_send_alert = (
-                get_bool("SEND_FROM_WEBHOOK", False)
-                and (course_status == "O" or course_status == "C")
-                and get_current_semester() == course_term
-            )
-
-            if should_send_alert:
+            if should_send_pca_alert(course_term, course_status):
                 try:
                     alert_for_course(
                         course_id, semester=course_term, sent_by="WEB", course_status=course_status

--- a/backend/alert/models.py
+++ b/backend/alert/models.py
@@ -100,8 +100,9 @@ class Registration(models.Model):
     Alerts are triggered by webhook requests from the UPenn OpenData API
     (https://esb.isc-seo.upenn.edu/8091/documentation/#coursestatuswebhookservice), and accepted
     by alert/views.py/accept_webhook. Then if the SEND_FROM_WEBHOOK Option is set to True,
-    the semester of the webhook request equals courses.util.get_current_semester(), and the new
-    course status is either "O" (meaning open) or "C" (meaning closed), the method calls
+    the semester of the webhook request equals courses.util.get_current_semester(), the new
+    course status is either "O" (meaning open) or "C" (meaning closed), and the current datetime
+    is less than the current AddDropPeriod's end field (if not null), then the method calls
     alert/views.py/alert_for_course for the relevant course.  That method then calls
     alert/tasks.py/send_course_alerts asynchronously using the Celery delay function.
     This allows for alerts to be queued without holding up the response.  The send_course_alerts

--- a/backend/alert/tasks.py
+++ b/backend/alert/tasks.py
@@ -11,9 +11,9 @@ from django.db import transaction
 from alert.models import PcaDemandDistributionEstimate, Registration
 from courses.models import Section, StatusUpdate
 from courses.util import (
-    get_or_create_add_drop_period,
     get_course_and_section,
     get_current_semester,
+    get_or_create_add_drop_period,
     update_course_from_record,
 )
 from PennCourses.settings.base import ROUGH_MINIMUM_DEMAND_DISTRIBUTION_ESTIMATES

--- a/backend/alert/tasks.py
+++ b/backend/alert/tasks.py
@@ -11,7 +11,7 @@ from django.db import transaction
 from alert.models import PcaDemandDistributionEstimate, Registration
 from courses.models import Section, StatusUpdate
 from courses.util import (
-    get_add_drop_period,
+    get_or_create_add_drop_period,
     get_course_and_section,
     get_current_semester,
     update_course_from_record,
@@ -145,7 +145,7 @@ def registration_update(section_id, was_active, is_now_active, updated_at):
                     np.percentile(closed_sections_demand_values, 75) if csdv_nonempty else None
                 ),
             )
-            add_drop_period = get_add_drop_period(semester)
+            add_drop_period = get_or_create_add_drop_period(semester)
             new_demand_distribution_estimate.save(add_drop_period=add_drop_period)
             new_demand_distribution_estimate.created_at = updated_at
             new_demand_distribution_estimate.save(add_drop_period=add_drop_period)

--- a/backend/alert/util.py
+++ b/backend/alert/util.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from dateutil.tz.tz import gettz
 from options.models import get_bool
 
-from courses.util import get_or_create_add_drop_period, get_current_semester
+from courses.util import get_current_semester, get_or_create_add_drop_period
 from PennCourses.settings.base import TIME_ZONE
 
 

--- a/backend/alert/util.py
+++ b/backend/alert/util.py
@@ -27,6 +27,6 @@ def should_send_pca_alert(course_term, course_status):
         and (course_status == "O" or course_status == "C")
         and (
             add_drop_period.end is None
-            or add_drop_period.end > datetime.utcnow().replace(tzinfo=gettz(TIME_ZONE))
+            or datetime.utcnow().replace(tzinfo=gettz(TIME_ZONE)) < add_drop_period.end
         )
     )

--- a/backend/alert/util.py
+++ b/backend/alert/util.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from dateutil.tz.tz import gettz
+from options.models import get_bool
+
+from courses.util import get_or_create_add_drop_period, get_current_semester
+from PennCourses.settings.base import TIME_ZONE
+
+
+def pca_registration_open():
+    """
+    Returns True iff PCA should be accepting new registrations.
+    """
+    current_adp = get_or_create_add_drop_period(semester=get_current_semester())
+    return get_bool("REGISTRATION_OPEN", True) and (
+        current_adp.end is None
+        or datetime.utcnow().replace(tzinfo=gettz(TIME_ZONE)) < current_adp.end
+    )
+
+
+def should_send_pca_alert(course_term, course_status):
+    if get_current_semester() != course_term:
+        return False
+    add_drop_period = get_or_create_add_drop_period(course_term)
+    return (
+        get_bool("SEND_FROM_WEBHOOK", False)
+        and (course_status == "O" or course_status == "C")
+        and (
+            add_drop_period.end is None
+            or add_drop_period.end > datetime.utcnow().replace(tzinfo=gettz(TIME_ZONE))
+        )
+    )

--- a/backend/courses/management/commands/deduplicate_status_updates.py
+++ b/backend/courses/management/commands/deduplicate_status_updates.py
@@ -1,0 +1,29 @@
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+from alert.management.commands.recomputestats import deduplicate_status_updates
+
+
+class Command(BaseCommand):
+    help = "Remove duplicate/redundant status updates from the given semesters."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--semesters",
+            type=str,
+            help=dedent(
+                """
+                The semesters argument should be a comma-separated list of semesters
+            corresponding to the semesters for which you want to remove duplicate/redundant
+            status updates, i.e. "2019C,2020A,2020C" for fall 2019, spring 2020, and fall 2020.
+            If this argument is omitted, stats are only recomputed for the current semester.
+            If you pass "all" to this argument, this script will remove duplicate/redundant
+            status updates for all semesters found in Courses in the db.
+                """
+            ),
+            nargs="?",
+            default=None,
+        )
+
+    def handle(self, *args, **kwargs):
+        deduplicate_status_updates(semesters=kwargs["semesters"], verbose=True)

--- a/backend/courses/management/commands/deduplicate_status_updates.py
+++ b/backend/courses/management/commands/deduplicate_status_updates.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 
 from django.core.management.base import BaseCommand
+
 from alert.management.commands.recomputestats import deduplicate_status_updates
 
 

--- a/backend/courses/management/commands/load_add_drop_dates.py
+++ b/backend/courses/management/commands/load_add_drop_dates.py
@@ -11,7 +11,7 @@ from django.utils.timezone import make_aware
 
 from alert.models import AddDropPeriod, validate_add_drop_semester
 from courses.models import Course
-from courses.util import get_add_drop_period, get_current_semester, get_or_create_add_drop_period
+from courses.util import get_current_semester, get_or_create_add_drop_period
 from PennCourses.settings.base import TIME_ZONE
 
 
@@ -40,13 +40,9 @@ def load_add_drop_dates(verbose=False):
         print(f"Loading add/drop period dates for semester {semester} from the Almanac")
     with transaction.atomic():
         start_date, end_date = None, None
-        try:
-            previous = get_add_drop_period(semester)
-            start_date = previous.start
-            end_date = previous.end
-            previous.delete()
-        except AddDropPeriod.DoesNotExist:
-            pass
+        adp = get_or_create_add_drop_period(semester)
+        start_date = adp.start
+        end_date = adp.end
         html = requests.get("https://almanac.upenn.edu/penn-academic-calendar").content
         soup = BeautifulSoup(html, "html.parser")
         if semester[4] == "C":
@@ -144,7 +140,6 @@ def load_add_drop_dates(verbose=False):
                 datetime.strptime(f"{e_year}-{e_month}-{e_day} 11:59", "%Y-%m-%d %H:%M"),
                 timezone=tz,
             )
-        adp = get_or_create_add_drop_period(semester)
         adp.start, adp.end = start_date, end_date
         adp.save()
     if verbose:

--- a/backend/courses/models.py
+++ b/backend/courses/models.py
@@ -462,7 +462,7 @@ class Section(models.Model):
         registration period] that this section was open. If this section's registration
         period hasn't started yet, this property is null (None in Python).
         """
-        from courses.util import get_or_create_add_drop_period, get_current_semester
+        from courses.util import get_current_semester, get_or_create_add_drop_period
 
         # ^ imported here to avoid circular imports
 

--- a/backend/courses/models.py
+++ b/backend/courses/models.py
@@ -550,8 +550,6 @@ class StatusUpdate(models.Model):
         help_text="Was an alert was sent to a User as a result of this status update?"
     )
     # ^^^ alert_sent is true iff alert_for_course was called in accept_webhook in alert/views.py
-    # equivalently, iff SEND_FROM_WEBHOOK == True and SEMESTER == course_term, and the request
-    # is not otherwise invalid
     request_body = models.TextField()
 
     percent_through_add_drop_period = models.FloatField(

--- a/backend/courses/models.py
+++ b/backend/courses/models.py
@@ -462,12 +462,12 @@ class Section(models.Model):
         registration period] that this section was open. If this section's registration
         period hasn't started yet, this property is null (None in Python).
         """
-        from courses.util import get_add_drop_period, get_current_semester
+        from courses.util import get_or_create_add_drop_period, get_current_semester
 
         # ^ imported here to avoid circular imports
 
         if self.semester == get_current_semester():
-            add_drop = get_add_drop_period(self.semester)
+            add_drop = get_or_create_add_drop_period(self.semester)
             add_drop_start = add_drop.estimated_start
             add_drop_end = add_drop.estimated_end
             current_time = timezone.now()
@@ -577,13 +577,13 @@ class StatusUpdate(models.Model):
     def save(self, *args, **kwargs):
         """
         This overridden save method first gets the add/drop period object for the semester of this
-        StatusUpdate object (either by using the get_add_drop_period method or by using
+        StatusUpdate object (either by using the get_or_create_add_drop_period method or by using
         a passed-in add_drop_period kwarg, which can be used for efficiency in bulk operations
         over many StatusUpdate objects). Then it calls the overridden save method, and after that
         it sets the percent_through_add_drop_period field.
         """
         from alert.models import validate_add_drop_semester
-        from courses.util import get_add_drop_period
+        from courses.util import get_or_create_add_drop_period
 
         # ^ imported here to avoid circular imports
 
@@ -601,7 +601,7 @@ class StatusUpdate(models.Model):
             return
 
         if add_drop_period is None:
-            add_drop_period = get_add_drop_period(self.section.semester)
+            add_drop_period = get_or_create_add_drop_period(self.section.semester)
 
         created_at = self.created_at
         start = add_drop_period.estimated_start

--- a/backend/review/views.py
+++ b/backend/review/views.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from courses.models import Course, Department, Instructor, Restriction, Section, StatusUpdate
-from courses.util import get_or_create_add_drop_period, get_current_semester
+from courses.util import get_current_semester, get_or_create_add_drop_period
 from PennCourses.docs_settings import PcxAutoSchema, reverse_func
 from PennCourses.settings.base import TIME_ZONE, WAITLIST_DEPARTMENT_CODES
 from review.annotations import annotate_average_and_recent, review_averages

--- a/backend/review/views.py
+++ b/backend/review/views.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from courses.models import Course, Department, Instructor, Restriction, Section, StatusUpdate
-from courses.util import get_add_drop_period, get_current_semester
+from courses.util import get_or_create_add_drop_period, get_current_semester
 from PennCourses.docs_settings import PcxAutoSchema, reverse_func
 from PennCourses.settings.base import TIME_ZONE, WAITLIST_DEPARTMENT_CODES
 from review.annotations import annotate_average_and_recent, review_averages
@@ -249,7 +249,7 @@ def course_plots(request, course_code):
             recent_percent_open_plot_semester,
         ) = avg_and_recent_percent_open_plots(section_map, status_updates_map)
 
-    current_adp = get_add_drop_period(current_semester)
+    current_adp = get_or_create_add_drop_period(current_semester)
     local_tz = gettz(TIME_ZONE)
 
     return Response(

--- a/backend/tests/alert/test_alert.py
+++ b/backend/tests/alert/test_alert.py
@@ -767,6 +767,22 @@ class WebhookViewTestCase(TestCase):
         u = StatusUpdate.objects.get()
         self.assertFalse(u.alert_sent)
 
+    def test_not_current_semester(self, mock_alert):
+        self.body["term"] = "3021C"
+        res = self.client.post(
+            reverse("webhook", urlconf="alert.urls"),
+            data=json.dumps(self.body),
+            content_type="application/json",
+            **self.headers,
+        )
+
+        self.assertEqual(200, res.status_code)
+        self.assertFalse("sent" in json.loads(res.content)["message"])
+        self.assertFalse(mock_alert.called)
+        self.assertEqual(1, StatusUpdate.objects.count())
+        u = StatusUpdate.objects.get()
+        self.assertFalse(u.alert_sent)
+
     def test_bad_format(self, mock_alert):
         self.body = {"hello": "world"}
         res = self.client.post(

--- a/backend/tests/alert/test_deduplicate_status_updates.py
+++ b/backend/tests/alert/test_deduplicate_status_updates.py
@@ -1,0 +1,116 @@
+from django.db.models.signals import post_save
+from django.test.testcases import TestCase
+from options.models import Option
+
+from alert.management.commands.recomputestats import deduplicate_status_updates
+from alert.models import AddDropPeriod
+from courses.models import StatusUpdate
+from courses.util import get_or_create_course_and_section, invalidate_current_semester_cache
+
+
+TEST_SEMESTER = "2019A"
+
+
+def set_semester():
+    post_save.disconnect(
+        receiver=invalidate_current_semester_cache,
+        sender=Option,
+        dispatch_uid="invalidate_current_semester_cache",
+    )
+    Option(key="SEMESTER", value=TEST_SEMESTER, value_type="TXT").save()
+    AddDropPeriod(semester=TEST_SEMESTER).save()
+
+
+class DeduplicateStatusUpdatesTestCase(TestCase):
+    def setUp(self):
+        set_semester()
+        self.sections = []
+        self.sections.append(get_or_create_course_and_section("CIS-160-001", TEST_SEMESTER)[1])
+        self.sections.append(get_or_create_course_and_section("CIS-160-002", TEST_SEMESTER)[1])
+        self.sections.append(get_or_create_course_and_section("CIS-120-001", TEST_SEMESTER)[1])
+        self.old_section = get_or_create_course_and_section("CIS-120-001", "2017C")[1]
+
+    def test_no_duplicates(self):
+        StatusUpdate(
+            section=self.sections[0], old_status="", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="O", new_status="C", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="C", new_status="O", alert_sent=False
+        ).save()
+
+        StatusUpdate(
+            section=self.sections[1], old_status="X", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[1], old_status="O", new_status="C", alert_sent=False
+        ).save()
+
+        StatusUpdate(
+            section=self.old_section, old_status="C", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.old_section, old_status="O", new_status="C", alert_sent=False
+        ).save()
+
+        self.assertEqual(
+            5, StatusUpdate.objects.filter(section__course__semester=TEST_SEMESTER).count()
+        )
+        self.assertEqual(2, StatusUpdate.objects.filter(section__course__semester="2017C").count())
+        deduplicate_status_updates(semesters="all")
+        self.assertEqual(
+            5, StatusUpdate.objects.filter(section__course__semester=TEST_SEMESTER).count()
+        )
+        self.assertEqual(2, StatusUpdate.objects.filter(section__course__semester="2017C").count())
+
+    def test_some_duplicates(self):
+        StatusUpdate(
+            section=self.sections[0], old_status="", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="O", new_status="C", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="O", new_status="C", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[0], old_status="C", new_status="O", alert_sent=False
+        ).save()
+
+        StatusUpdate(
+            section=self.sections[1], old_status="X", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[1], old_status="X", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.sections[1], old_status="O", new_status="C", alert_sent=False
+        ).save()
+
+        StatusUpdate(
+            section=self.old_section, old_status="C", new_status="O", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.old_section, old_status="O", new_status="C", alert_sent=False
+        ).save()
+        StatusUpdate(
+            section=self.old_section, old_status="O", new_status="C", alert_sent=False
+        ).save()
+
+        self.assertEqual(
+            9, StatusUpdate.objects.filter(section__course__semester=TEST_SEMESTER).count()
+        )
+        self.assertEqual(3, StatusUpdate.objects.filter(section__course__semester="2017C").count())
+        deduplicate_status_updates(semesters="all")
+        self.assertEqual(
+            5, StatusUpdate.objects.filter(section__course__semester=TEST_SEMESTER).count()
+        )
+        self.assertEqual(2, StatusUpdate.objects.filter(section__course__semester="2017C").count())

--- a/backend/tests/review/test_stats.py
+++ b/backend/tests/review/test_stats.py
@@ -390,6 +390,16 @@ class TwoSemestersOneInstructorTestCase(TestCase, PCRTestMixin):
             },
         )
 
+    def test_current_percent_open(self):
+        self.assertAlmostEquals(
+            self.recent_percent_open,
+            Section.objects.get(id=self.ESE_120_001_TEST_SEMESTER_id).current_percent_open,
+        )
+        self.assertAlmostEquals(
+            self.old_percent_open,
+            Section.objects.get(id=self.ESE_120_001_2020C_id).current_percent_open,
+        )
+
 
 class OneReviewTestCase(TestCase, PCRTestMixin):
     @classmethod


### PR DESCRIPTION
This PR adds a script to remove duplicate status updates due to a known bug in the OpenAPI webhook that will send duplicate webhook requests from time to time. It also adds logic to automatically close PCA registrations and disable alerting after the end of the add/drop period (using the add/drop end date scraped from the academic calendar).