### PR TITLE
Accept course query param to autofill PCA form

### DIFF
--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -92,10 +92,16 @@ interface AlertFormProps {
     user: User;
     setResponse: (res: Response) => void;
     setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
+    autofillSection?: string;
 }
 
-const AlertForm = ({ user, setResponse, setTimeline }: AlertFormProps) => {
-    const [section, setSection] = useState("");
+const AlertForm = ({
+    user,
+    setResponse,
+    setTimeline,
+    autofillSection = "",
+}: AlertFormProps) => {
+    const [section, setSection] = useState(autofillSection);
     const [email, setEmail] = useState("");
 
     const [phone, setPhone] = useState("");
@@ -176,7 +182,11 @@ const AlertForm = ({ user, setResponse, setTimeline }: AlertFormProps) => {
 
     return (
         <Form>
-            <AutoComplete onValueChange={setSection} setTimeline={setTimeline}/>
+            <AutoComplete
+                defaultValue={autofillSection}
+                onValueChange={setSection}
+                setTimeline={setTimeline}
+            />
             <Input
                 placeholder="Email"
                 value={email}

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -388,7 +388,7 @@ const AutoComplete = ({ defaultValue="", onValueChange, setTimeline, disabled })
 };
 
 AutoComplete.propTypes = {
-    defaultValue: string | undefined,
+    defaultValue: PropTypes.string,
     onValueChange: PropTypes.func,
     disabled: PropTypes.bool,
 };

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -1,6 +1,6 @@
 import React, { RefObject, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
+import PropTypes, { string } from "prop-types";
 
 import AwesomeDebouncePromise from "awesome-debounce-promise";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -226,9 +226,9 @@ interface TSuggestion {
     searchTerm: string;
 }
 
-const AutoComplete = ({ onValueChange, setTimeline, disabled }) => {
+const AutoComplete = ({ defaultValue="", onValueChange, setTimeline, disabled }) => {
     const inputRef = useRef<HTMLInputElement>(null);
-    const [value, setInternalValue] = useState("");
+    const [value, setInternalValue] = useState(defaultValue);
     const [suggestions, setSuggestions] = useState<Section[]>([]);
     const [
         suggestionsFromBackend,
@@ -293,6 +293,7 @@ const AutoComplete = ({ onValueChange, setTimeline, disabled }) => {
             ref={useOnClickOutside(() => setActive(false), !show)}
         >
             <AutoCompleteInput
+                defaultValue={defaultValue}
                 disabled={disabled}
                 // @ts-ignore
                 autocomplete="off"
@@ -387,6 +388,7 @@ const AutoComplete = ({ onValueChange, setTimeline, disabled }) => {
 };
 
 AutoComplete.propTypes = {
+    defaultValue: string | undefined,
     onValueChange: PropTypes.func,
     disabled: PropTypes.bool,
 };

--- a/frontend/alert/pages/index.tsx
+++ b/frontend/alert/pages/index.tsx
@@ -3,6 +3,7 @@ import usePlatformOptions from "pcx-shared-components/src/data-hooks/usePlatform
 import styled from "styled-components";
 import ReactGA from "react-ga";
 import * as Sentry from "@sentry/browser";
+import { useRouter } from "next/router";
 
 import AccountIndicator from "pcx-shared-components/src/accounts/AccountIndicator";
 import ManageAlertWrapper from "../components/managealert";
@@ -123,6 +124,7 @@ const RecruitingBanner = styled.div`
 `;
 
 function App() {
+    const router = useRouter();
     const [user, setUser] = useState<User | null>(null);
     const [page, setPage] = useState("home");
     const [messages, setMessages] = useState<
@@ -219,7 +221,12 @@ function App() {
                 {page === "home" ? (
                     <Flex col grow={1}>
                         {user ? (
-                            <AlertForm user={user} setResponse={setResponse} setTimeline={setTimeline}/>
+                            <AlertForm
+                                user={user}
+                                setResponse={setResponse}
+                                setTimeline={setTimeline}
+                                autofillSection={router.query.course as string}
+                            />
                         ) : null}
                     </Flex>
                 ) : (


### PR DESCRIPTION
Make urls like [https://penncoursealert.com/?course=DSGN-264-405](https://penncoursealert.com/?course=DSGN-264-405) work (autofill course code in PCA form).