### PR TITLE
Reduce Twilio costs

### DIFF
--- a/backend/alert/templates/alert/text_alert.txt
+++ b/backend/alert/templates/alert/text_alert.txt
@@ -1,3 +1,3 @@
-{{course}} is now open! Register on PennInTouch: http://bit.ly/pitouch.
-{% if auto_resubscribe %}To cancel alerts, visit{% else %}Resubscribe at{% endif %} http://penncoursealert.com#manage
+{{course}} is open! Register on PennInTouch: http://bit.ly/pitouch.
+{% if auto_resubscribe %}To cancel alerts, visit{% else %}Resubscribe at{% endif %} http://u.pennlabs.org/pca
 - Thanks for using Penn Course Alert!


### PR DESCRIPTION
This PR should basically cut our twilio costs in half. Previously messages used 2 segments but this message is shorter and can be sent in a single segment.

Use https://twiliodeved.github.io/message-segment-calculator/ to determine the number of segments a text would be.