### PR TITLE
PCA Bulk Registration

### DIFF
--- a/backend/courses/serializers.py
+++ b/backend/courses/serializers.py
@@ -99,6 +99,7 @@ class MiniSectionSerializer(serializers.ModelSerializer):
             "course_code",
             "course_title",
             "semester",
+            "registration_volume",
         ]
         read_only_fields = fields
 
@@ -174,7 +175,9 @@ class SectionDetailSerializer(serializers.ModelSerializer):
             "instructor_quality",
             "difficulty",
             "work_required",
-        ] + ["associated_sections",]
+            "associated_sections",
+            "registration_volume",
+        ]
         read_only_fields = fields
 
 

--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -5,9 +5,9 @@ import * as Sentry from "@sentry/browser";
 
 import { parsePhoneNumberFromString } from "libphonenumber-js/min";
 
+import { Center } from "pcx-shared-components/src/common/layout";
 import { Input } from "../Input";
 import AutoComplete from "../AutoComplete";
-import { Center } from "pcx-shared-components/src/common/layout";
 import getCsrf from "../../csrf";
 import { User } from "../../types";
 

--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -141,6 +141,11 @@ const AlertForm = ({
         );
     };
 
+    // Clear all sections the user selected
+    const clearSelections = () => {
+        setSelectedCourses(new Set());
+    }
+
     const submitRegistration = () => {
         //if user has a auto fill section and didn't change the input value then register for section
         if (autoCompleteInputRef.current && autoCompleteInputRef.current.value == autofillSection) {
@@ -164,9 +169,22 @@ const AlertForm = ({
             promises.push(promise)
         })
 
+        let success = true;
         Promise.all(promises)
-            .then((responses) => responses.map(res => setResponse(res)))
-            .catch(handleError);
+            .then((responses) => {
+                responses.forEach(res => setResponse(res));
+                success = false;
+                console.log(success);
+            })
+            .catch(handleError)
+            .finally(() => {
+                if (success) {
+                    sendError(201, "Successfully registered for all sections!")
+                    clearSelections();
+                }
+            })
+        
+        
     };
 
     const onSubmit = () => {
@@ -210,6 +228,7 @@ const AlertForm = ({
                 setSelectedCourses={setSelectedCourses}
                 setTimeline={setTimeline}
                 inputRef={autoCompleteInputRef}
+                clearSelections={clearSelections}
             />
             <Input
                 placeholder="Email"

--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -172,7 +172,7 @@ const AlertForm = ({
         let success = true;
         Promise.all(promises)
             .then((responses) => {
-                responses.forEach(res => setResponse(res));
+                responses.forEach((res: Response) => setResponse(res));
                 success = false;
                 console.log(success);
             })

--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -159,7 +159,7 @@ const AlertForm = ({
         // if user has a auto fill section and didn't change the input value then register for section
         if (
             autoCompleteInputRef.current &&
-            autoCompleteInputRef.current.value == autofillSection
+            autoCompleteInputRef.current.value === autofillSection
         ) {
             doAPIRequest("/api/alert/registrations/", "POST", {
                 section: autofillSection,
@@ -179,12 +179,13 @@ const AlertForm = ({
             promises.push(promise);
         });
 
-        let sections = Array.from(selectedCourses)
+        const sections = Array.from(selectedCourses)
 
         Promise.allSettled(promises)
             .then((responses) => responses.forEach(
                 (res: PromiseSettledResult<Response>, i) => {
                     if (res.status === "fulfilled") {
+                        console.log("fulfilled")
                         setResponse(res.value);
                         deselectCourse(sections[i]);
                     } else {

--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -101,7 +101,9 @@ const AlertForm = ({
     setTimeline,
     autofillSection = "",
 }: AlertFormProps) => {
-    const [selectedCourses, setSelectedCourses] = useState<Set<Section>>(new Set())
+    const [selectedCourses, setSelectedCourses] = useState<Set<Section>>(
+        new Set()
+    );
 
     const [email, setEmail] = useState("");
 
@@ -144,11 +146,14 @@ const AlertForm = ({
     // Clear all sections the user selected
     const clearSelections = () => {
         setSelectedCourses(new Set());
-    }
+    };
 
     const submitRegistration = () => {
-        //if user has a auto fill section and didn't change the input value then register for section
-        if (autoCompleteInputRef.current && autoCompleteInputRef.current.value == autofillSection) {
+        // if user has a auto fill section and didn't change the input value then register for section
+        if (
+            autoCompleteInputRef.current &&
+            autoCompleteInputRef.current.value == autofillSection
+        ) {
             doAPIRequest("/api/alert/registrations/", "POST", {
                 section: autofillSection,
                 auto_resubscribe: autoResub === "true",
@@ -157,17 +162,15 @@ const AlertForm = ({
                 .catch(handleError);
         }
 
-        selectedCourses.forEach((section) => console.log(section.section_id))
-
         // register all selected sections
-        let promises: any = []
+        const promises: any = [];
         selectedCourses.forEach((section) => {
             const promise = doAPIRequest("/api/alert/registrations/", "POST", {
                 section: section.section_id,
                 auto_resubscribe: autoResub === "true",
-            })
-            promises.push(promise)
-        })
+            });
+            promises.push(promise);
+        });
 
         let success = true;
         Promise.all(promises)
@@ -179,12 +182,10 @@ const AlertForm = ({
             .catch(handleError)
             .finally(() => {
                 if (success) {
-                    sendError(201, "Successfully registered for all sections!")
+                    sendError(201, "Successfully registered for all sections!");
                     clearSelections();
                 }
-            })
-        
-        
+            });
     };
 
     const onSubmit = () => {

--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -158,12 +158,12 @@ const AlertForm = ({
                 section: autofillSection,
                 auto_resubscribe: autoResub === "true",
             })
-                .then((res) => setResponse(res))
+                .then(setResponse)
                 .catch(handleError);
         }
 
         // register all selected sections
-        const promises: any = [];
+        const promises: Array<Promise<Response>> = [];
         selectedCourses.forEach((section) => {
             const promise = doAPIRequest("/api/alert/registrations/", "POST", {
                 section: section.section_id,

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -137,19 +137,28 @@ interface TSuggestion {
     searchTerm: string;
 }
 
+interface AutoCompleteProps {
+    defaultValue: string;
+    setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
+    selectedCourses: Set<Section>,
+    setSelectedCourses: React.Dispatch<React.SetStateAction<Set<Section>>>,
+    inputRef: React.RefObject<HTMLInputElement>,
+    clearSelections: () => void,
+}
+
+
 const AutoComplete = ({
     defaultValue = "",
     setTimeline,
-    disabled,
     selectedCourses,
     setSelectedCourses,
     inputRef,
     clearSelections,
-}) => {
+}: AutoCompleteProps) => {
     const initialRender = useRef(true);
     const inputValDelete = useRef(false);
 
-    const [value, setInternalValue] = useState(defaultValue);
+    const [value, setValue] = useState(defaultValue);
     const [suggestions, setSuggestions] = useState<Section[]>([]);
     const [
         suggestionsFromBackend,
@@ -160,10 +169,6 @@ const AutoComplete = ({
 
     const show = active && suggestions.length > 0;
     const bulkMode = selectedCourses.size > 1;
-
-    const setValue = (v) => {
-        return setInternalValue(v);
-    };
 
     useEffect(() => {
         // Don't run if first render to prevent defaultValue of value from emptying
@@ -179,7 +184,7 @@ const AutoComplete = ({
                 inputRef.current.value = generateCoursesValue();
             } else if (selectedCourses.size == 1) {
                 // display the one selected section
-                setInternalValue(
+                setValue(
                     selectedCourses.values().next().value.section_id
                 );
                 inputRef.current.value = selectedCourses
@@ -189,7 +194,7 @@ const AutoComplete = ({
                 // No sections selected, clear input and suggestions
                 // Run when the only course that was selected is unselected
                 inputRef.current.value = "";
-                setInternalValue("");
+                setValue("");
             } else {
                 inputValDelete.current = false;
             }
@@ -266,6 +271,8 @@ const AutoComplete = ({
             return res;
         }, {});
 
+    console.log(groupedSuggestions);
+
     return (
         <Container
             inputHeight={
@@ -278,7 +285,6 @@ const AutoComplete = ({
             <AutoCompleteInputContainer>
                 <AutoCompleteInput
                     defaultValue={defaultValue}
-                    disabled={disabled}
                     readOnly={bulkMode}
                     // @ts-ignore
                     autocomplete="off"
@@ -345,7 +351,7 @@ const AutoComplete = ({
                 <AutoCompleteInputBackground
                     // @ts-ignore
                     autocomplete="off"
-                    disabled={disabled || bulkMode}
+                    disabled={bulkMode}
                     value={bulkMode ? "" : backdrop}
                 />
                 <ClearSelection
@@ -373,12 +379,6 @@ const AutoComplete = ({
             </DropdownContainer>
         </Container>
     );
-};
-
-AutoComplete.propTypes = {
-    defaultValue: PropTypes.string,
-    onValueChange: PropTypes.func,
-    disabled: PropTypes.bool,
 };
 
 export default AutoComplete;

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -156,7 +156,6 @@ const AutoComplete = ({
     clearSelections,
 }: AutoCompleteProps) => {
     const initialRender = useRef(true);
-    const inputValDelete = useRef(false);
 
     const [value, setValue] = useState(defaultValue);
     const [suggestions, setSuggestions] = useState<Section[]>([]);
@@ -190,11 +189,7 @@ const AutoComplete = ({
                 inputRef.current.value = selectedCourses
                     .values()
                     .next().value.section_id;
-            } else {
-                console.log(inputRef.current.value);
-                inputRef.current.value = inputRef.current.value;
-                console.log(inputRef.current.value);
-            }
+            } 
         }
     }, [selectedCourses]);
 
@@ -214,15 +209,6 @@ const AutoComplete = ({
             }
         }
     }, [suggestionsFromBackend, value]);
-
-    // Clear the input value and set current value the suggestions are based on to empty
-    const clearInput = () => {
-        if (inputRef.current) {
-            inputRef.current.value = "";
-            console.log(value);
-            setValue("");
-        }
-    }
 
     // Create input text for bulk mode in the form of: [last selected section title] + [# selected courses - 1] more
     const generateCoursesValue = () => {
@@ -275,8 +261,6 @@ const AutoComplete = ({
 
             return res;
         }, {});
-
-    console.log(groupedSuggestions);
 
     return (
         <Container
@@ -336,7 +320,6 @@ const AutoComplete = ({
                             e.keyCode === DELETE_KEY &&
                             selectedCourses.size === 1
                         ) {
-                            inputValDelete.current = true;
                             clearSelections();
                         } else {
                             // @ts-ignore
@@ -378,7 +361,6 @@ const AutoComplete = ({
                             setValue={setValue}
                             setTimeline={setTimeline}
                             setSelectedCourses={setSelectedCourses}
-                            clearInput={clearInput}
                         />
                     ))}
                 </DropdownBox>

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -283,6 +283,24 @@ const AutoComplete = ({ defaultValue="", onValueChange, setTimeline, disabled })
             .map((suggestion) => suggestion.section_id.toLowerCase())
             .indexOf(value.toLowerCase());
 
+
+    /**
+     * Returns suggested suggestion grouped by course
+     * @return suggestions
+     */
+    const groupedSuggestions = suggestions.reduce((res, obj) => {
+        let [courseName, midNum, endNum] = obj.section_id.split('-');
+        if (res[courseName + '-' + midNum]) {
+            res[courseName + '-' + midNum].push(obj);
+        } else {
+            res[courseName + '-' + midNum] = [obj];
+        }
+
+        return res;
+    },{});
+
+    console.log(groupedSuggestions);
+
     return (
         <Container
             inputHeight={

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -141,7 +141,8 @@ const AutoComplete = ({
     disabled,
     selectedCourses,
     setSelectedCourses,
-    inputRef
+    inputRef,
+    clearSelections
 }) => {
     const initialRender = useRef(true);
     const [value, setInternalValue] = useState(defaultValue);
@@ -200,11 +201,6 @@ const AutoComplete = ({
             }
         }
     }, [suggestionsFromBackend, value]);
-
-    // Clear all sections the user selected
-    const clearSelections = () => {
-        setSelectedCourses(new Set());
-    }
 
     // Create input text for bulk mode in the form of: [last selected section title] + [# selected courses - 1] more
     const generateCoursesValue = () => {

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -182,7 +182,7 @@ const AutoComplete = ({
             if (bulkMode) {
                 // display all sections selected
                 inputRef.current.value = generateCoursesValue();
-            } else if (selectedCourses.size == 1) {
+            } else if (selectedCourses.size === 1) {
                 // display the one selected section
                 setValue(
                     selectedCourses.values().next().value.section_id
@@ -190,13 +190,10 @@ const AutoComplete = ({
                 inputRef.current.value = selectedCourses
                     .values()
                     .next().value.section_id;
-            } else if (!inputValDelete.current) {
-                // No sections selected, clear input and suggestions
-                // Run when the only course that was selected is unselected
-                inputRef.current.value = "";
-                setValue("");
             } else {
-                inputValDelete.current = false;
+                console.log(inputRef.current.value);
+                inputRef.current.value = inputRef.current.value;
+                console.log(inputRef.current.value);
             }
         }
     }, [selectedCourses]);
@@ -217,6 +214,15 @@ const AutoComplete = ({
             }
         }
     }, [suggestionsFromBackend, value]);
+
+    // Clear the input value and set current value the suggestions are based on to empty
+    const clearInput = () => {
+        if (inputRef.current) {
+            inputRef.current.value = "";
+            console.log(value);
+            setValue("");
+        }
+    }
 
     // Create input text for bulk mode in the form of: [last selected section title] + [# selected courses - 1] more
     const generateCoursesValue = () => {
@@ -328,7 +334,7 @@ const AutoComplete = ({
                             handleSuggestionSelect(newSelectedSuggestion);
                         } else if (
                             e.keyCode === DELETE_KEY &&
-                            selectedCourses.size == 1
+                            selectedCourses.size === 1
                         ) {
                             inputValDelete.current = true;
                             clearSelections();
@@ -372,6 +378,7 @@ const AutoComplete = ({
                             setValue={setValue}
                             setTimeline={setTimeline}
                             setSelectedCourses={setSelectedCourses}
+                            clearInput={clearInput}
                         />
                     ))}
                 </DropdownBox>

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -9,7 +9,7 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { useOnClickOutside } from "pcx-shared-components/src/useOnClickOutside";
 import { Input } from "./Input";
 import { Section } from "../types";
-import GroupSuggestion from "./GroupSuggestion"
+import GroupSuggestion from "./GroupSuggestion";
 
 /* A function that takes in a search term and returns a promise with both the search term and
 the search results.
@@ -89,26 +89,27 @@ const Container = styled.div<{ inputHeight: string }>`
     height: ${(props) => props.inputHeight};
 `;
 
-const AutoCompleteInputContainer = styled.div`
-    
-`
-const ClearSelection = styled(FontAwesomeIcon)<{ hidden?: boolean, parent: RefObject<HTMLInputElement> }>`
-   display: ${(props) => props.hidden ? "none" : "block"};
-   top: ${({ parent }) =>
-   parent.current &&
-   parent.current.getBoundingClientRect().height / 2}px;
-   right: 5px;
-   padding: 0 8px;
-   position: absolute;
-   cursor: pointer;
-   font-size: 1.25rem;
-   color: #c4c4c4;
-   z-index: 100;
+const AutoCompleteInputContainer = styled.div``;
 
-   &:hover {
-    color: #e8746a;
-   }
-`
+const ClearSelection = styled(FontAwesomeIcon)<{
+    hidden?: boolean;
+    parent: RefObject<HTMLInputElement>;
+}>`
+    display: ${(props) => (props.hidden ? "none" : "block")};
+    top: ${({ parent }) =>
+        parent.current && parent.current.getBoundingClientRect().height / 2}px;
+    right: 5px;
+    padding: 0 8px;
+    position: absolute;
+    cursor: pointer;
+    font-size: 1.25rem;
+    color: #c4c4c4;
+    z-index: 100;
+
+    &:hover {
+        color: #e8746a;
+    }
+`;
 
 /**
  * Given a current input value and a list of suggestions, generates the backdrop text for the
@@ -143,7 +144,7 @@ const AutoComplete = ({
     selectedCourses,
     setSelectedCourses,
     inputRef,
-    clearSelections
+    clearSelections,
 }) => {
     const initialRender = useRef(true);
     const inputValDelete = useRef(false);
@@ -165,37 +166,36 @@ const AutoComplete = ({
     };
 
     useEffect(() => {
-        //Don't run if first render to prevent defaultValue of value from emptying
+        // Don't run if first render to prevent defaultValue of value from emptying
         if (initialRender.current) {
             initialRender.current = false;
             return;
         }
 
-        //update suggestions and input value 
+        // update suggestions and input value
         if (inputRef.current) {
             if (bulkMode) {
-                //display all sections selected
+                // display all sections selected
                 inputRef.current.value = generateCoursesValue();
             } else if (selectedCourses.size == 1) {
-                //display the one selected section
-                setInternalValue(selectedCourses.values().next().value.section_id);
-                inputRef.current.value = selectedCourses.values().next().value.section_id;
+                // display the one selected section
+                setInternalValue(
+                    selectedCourses.values().next().value.section_id
+                );
+                inputRef.current.value = selectedCourses
+                    .values()
+                    .next().value.section_id;
+            } else if (!inputValDelete.current) {
+                // No sections selected, clear input and suggestions
+                // Run when the only course that was selected is unselected
+                inputRef.current.value = "";
+                setInternalValue("");
             } else {
-                if (!inputValDelete.current) {
-                    
-                    //No sections selected, clear input and suggestions
-                    //Run when the only course that was selected is unselected
-                    inputRef.current.value = '';
-                    setInternalValue("");
-                } else {
-                    inputValDelete.current = false;
-                }
-                
+                inputValDelete.current = false;
             }
-            
         }
     }, [selectedCourses]);
-   
+
     // Create suggestion text, backdrop
     useEffect(() => {
         setBackdrop(
@@ -217,8 +217,8 @@ const AutoComplete = ({
     const generateCoursesValue = () => {
         let lastElement;
         for (lastElement of Array.from(selectedCourses));
-        return lastElement.section_id + " + " + (selectedCourses.size - 1) + " more";
-    }
+        return `${lastElement.section_id} + ${selectedCourses.size - 1} more`;
+    };
 
     /**
      * Takes in the index of a new selected suggestion and updates state accordingly
@@ -247,23 +247,24 @@ const AutoComplete = ({
      * Returns suggested suggestion grouped by course
      * @return suggestions
      */
-    const groupedSuggestions = suggestions.sort((a, b) => a.section_id.localeCompare(b.section_id)).reduce((res, obj) => {
-        const [courseName, midNum, endNum] = obj.section_id.split("-");
-        const activity = obj.activity;
-    
-        if (res[`${courseName}-${midNum}`]) {
-            if (res[`${courseName}-${midNum}`][activity]) {
-                res[`${courseName}-${midNum}`][activity].push(obj);
-            } else {
-                res[`${courseName}-${midNum}`][activity] = [obj];
-            }
-           
-        } else {
-            res[`${courseName}-${midNum}`] = {[activity]: [obj]};
-        }
+    const groupedSuggestions = suggestions
+        .sort((a, b) => a.section_id.localeCompare(b.section_id))
+        .reduce((res, obj) => {
+            const [courseName, midNum, endNum] = obj.section_id.split("-");
+            const { activity } = obj;
 
-        return res;
-    }, {});
+            if (res[`${courseName}-${midNum}`]) {
+                if (res[`${courseName}-${midNum}`][activity]) {
+                    res[`${courseName}-${midNum}`][activity].push(obj);
+                } else {
+                    res[`${courseName}-${midNum}`][activity] = [obj];
+                }
+            } else {
+                res[`${courseName}-${midNum}`] = { [activity]: [obj] };
+            }
+
+            return res;
+        }, {});
 
     return (
         <Container
@@ -289,7 +290,7 @@ const AutoComplete = ({
                         }
                     }}
                     onKeyUp={(e) => {
-                        //Only allow keying suggestions feature when selecting one section
+                        // Only allow keying suggestions feature when selecting one section
                         if (bulkMode) {
                             return;
                         }
@@ -320,10 +321,12 @@ const AutoComplete = ({
                                 -1
                             );
                             handleSuggestionSelect(newSelectedSuggestion);
-                        } else if (e.keyCode === DELETE_KEY && selectedCourses.size == 1) {
-                                inputValDelete.current = true;
-                                clearSelections();
-
+                        } else if (
+                            e.keyCode === DELETE_KEY &&
+                            selectedCourses.size == 1
+                        ) {
+                            inputValDelete.current = true;
+                            clearSelections();
                         } else {
                             // @ts-ignore
                             const newValue = e.target.value;
@@ -345,13 +348,26 @@ const AutoComplete = ({
                     disabled={disabled || bulkMode}
                     value={bulkMode ? "" : backdrop}
                 />
-                <ClearSelection icon={faTimes} hidden={!bulkMode} parent={inputRef} onClick={() => clearSelections()}/>
+                <ClearSelection
+                    icon={faTimes}
+                    hidden={!bulkMode}
+                    parent={inputRef}
+                    onClick={() => clearSelections()}
+                />
             </AutoCompleteInputContainer>
             <DropdownContainer below={inputRef} hidden={!show}>
                 <DropdownBox>
-                    {Object.keys(groupedSuggestions).map(key => (
-                        <GroupSuggestion sections={groupedSuggestions[key]} courseCode={key} value={value} 
-                        selectedCourses={selectedCourses} inputRef={inputRef} setValue={setValue} setTimeline={setTimeline} setSelectedCourses={setSelectedCourses}/>
+                    {Object.keys(groupedSuggestions).map((key) => (
+                        <GroupSuggestion
+                            sections={groupedSuggestions[key]}
+                            courseCode={key}
+                            value={value}
+                            selectedCourses={selectedCourses}
+                            inputRef={inputRef}
+                            setValue={setValue}
+                            setTimeline={setTimeline}
+                            setSelectedCourses={setSelectedCourses}
+                        />
                     ))}
                 </DropdownBox>
             </DropdownContainer>

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -137,11 +137,12 @@ interface TSuggestion {
 
 const AutoComplete = ({
     defaultValue = "",
-    onValueChange,
     setTimeline,
     disabled,
+    selectedCourses,
+    setSelectedCourses,
+    inputRef
 }) => {
-    const inputRef = useRef<HTMLInputElement>(null);
     const initialRender = useRef(true);
     const [value, setInternalValue] = useState(defaultValue);
     const [suggestions, setSuggestions] = useState<Section[]>([]);
@@ -151,13 +152,11 @@ const AutoComplete = ({
     ] = useState<TSuggestion | null>(null);
     const [active, setActive] = useState(false);
     const [backdrop, setBackdrop] = useState("");
-    const [selectedCourses, setSelectedCourses] = useState<Set<Section>>(new Set())
 
     const show = active && suggestions.length > 0;
     const bulkMode = selectedCourses.size > 1;
 
     const setValue = (v) => {
-        onValueChange(v);
         return setInternalValue(v);
     };
 

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -4,7 +4,7 @@ import PropTypes, { string } from "prop-types";
 
 import AwesomeDebouncePromise from "awesome-debounce-promise";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faHistory } from "@fortawesome/free-solid-svg-icons";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 import { useOnClickOutside } from "pcx-shared-components/src/useOnClickOutside";
 import { Input } from "./Input";
@@ -87,6 +87,22 @@ const Container = styled.div<{ inputHeight: string }>`
     margin-bottom: 1rem;
     height: ${(props) => props.inputHeight};
 `;
+
+const AutoCompleteInputContainer = styled.div`
+    
+`
+//do width / 2.
+const ClearSelection = styled(FontAwesomeIcon)<{ hidden?: boolean }>`
+   display: ${(props) => props.hidden ? "none" : "block"};
+   top: 22px;
+   right: 0;
+   padding: 0 8px;
+   position: absolute;
+   cursor: pointer;
+   font-size: 1.25rem;
+   color: #c4c4c4;
+   z-index: 100;
+`
 
 /**
  * Given a current input value and a list of suggestions, generates the backdrop text for the
@@ -232,67 +248,70 @@ const AutoComplete = ({
             }
             ref={useOnClickOutside(() => setActive(false), !show)}
         >
-            <AutoCompleteInput
-                defaultValue={defaultValue}
-                disabled={disabled}
-                readOnly={bulkMode}
-                // @ts-ignore
-                autocomplete="off"
-                placeholder="Course"
-                ref={inputRef}
-                onKeyDown={(e) => {
-                    if (e.keyCode === RETURN_KEY && suggestions) {
-                        e.preventDefault();
-                    }
-                }}
-                onKeyUp={(e) => {
-                    if (
-                        (e.keyCode === RIGHT_ARROW ||
-                            e.keyCode === RETURN_KEY) &&
-                        inputRef.current &&
-                        suggestions &&
-                        suggestions[0]
-                    ) {
-                        // autocomplete with backdrop when the right arrow key is pressed
-                        setValue(backdrop);
-                        setActive(false);
-                        inputRef.current.value = backdrop;
-                    } else if (e.keyCode === DOWN_ARROW && suggestions) {
-                        // select a suggestion when the down arrow key is pressed
-                        const newIndex = getCurrentIndex() + 1;
-                        const newSelectedSuggestion = Math.min(
-                            newIndex,
-                            suggestions.length - 1
-                        );
-                        handleSuggestionSelect(newSelectedSuggestion);
-                    } else if (e.keyCode === UP_ARROW && suggestions) {
-                        // select a suggestion when the up arrow key is pressed
-                        const newSelectedSuggestion = Math.max(
-                            getCurrentIndex() - 1,
-                            -1
-                        );
-                        handleSuggestionSelect(newSelectedSuggestion);
-                    } else {
-                        // @ts-ignore
-                        const newValue = e.target.value;
-                        setValue(newValue);
-                        if (!newValue || newValue.length < 3) {
-                            setSuggestions([]);
-                        } else {
-                            suggestionsDebounced(newValue).then(
-                                setSuggestionsFromBackend
-                            );
+            <AutoCompleteInputContainer>
+                <AutoCompleteInput
+                    defaultValue={defaultValue}
+                    disabled={disabled}
+                    readOnly={bulkMode}
+                    // @ts-ignore
+                    autocomplete="off"
+                    placeholder="Course"
+                    ref={inputRef}
+                    onKeyDown={(e) => {
+                        if (e.keyCode === RETURN_KEY && suggestions) {
+                            e.preventDefault();
                         }
-                    }
-                }}
-                onClick={() => setActive(true)}
-            />
-            <AutoCompleteInputBackground
-                // @ts-ignore
-                autocomplete="off"
-                disabled={disabled || bulkMode}
-                value={bulkMode ? "" : backdrop}
-            />
+                    }}
+                    onKeyUp={(e) => {
+                        if (
+                            (e.keyCode === RIGHT_ARROW ||
+                                e.keyCode === RETURN_KEY) &&
+                            inputRef.current &&
+                            suggestions &&
+                            suggestions[0]
+                        ) {
+                            // autocomplete with backdrop when the right arrow key is pressed
+                            setValue(backdrop);
+                            setActive(false);
+                            inputRef.current.value = backdrop;
+                        } else if (e.keyCode === DOWN_ARROW && suggestions) {
+                            // select a suggestion when the down arrow key is pressed
+                            const newIndex = getCurrentIndex() + 1;
+                            const newSelectedSuggestion = Math.min(
+                                newIndex,
+                                suggestions.length - 1
+                            );
+                            handleSuggestionSelect(newSelectedSuggestion);
+                        } else if (e.keyCode === UP_ARROW && suggestions) {
+                            // select a suggestion when the up arrow key is pressed
+                            const newSelectedSuggestion = Math.max(
+                                getCurrentIndex() - 1,
+                                -1
+                            );
+                            handleSuggestionSelect(newSelectedSuggestion);
+                        } else {
+                            // @ts-ignore
+                            const newValue = e.target.value;
+                            setValue(newValue);
+                            if (!newValue || newValue.length < 3) {
+                                setSuggestions([]);
+                            } else {
+                                suggestionsDebounced(newValue).then(
+                                    setSuggestionsFromBackend
+                                );
+                            }
+                        }
+                    }}
+                    onClick={() => setActive(true)}
+                />
+                <AutoCompleteInputBackground
+                    // @ts-ignore
+                    autocomplete="off"
+                    disabled={disabled || bulkMode}
+                    value={bulkMode ? "" : backdrop}
+                />
+                <ClearSelection icon={faTimes} hidden={!bulkMode}/>
+            </AutoCompleteInputContainer>
             <DropdownContainer below={inputRef} hidden={!show}>
                 <DropdownBox>
                     {Object.keys(groupedSuggestions).map(key => (

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -187,7 +187,6 @@ const AutoComplete = ({
                     //Run when the only course that was selected is unselected
                     inputRef.current.value = '';
                     setInternalValue("");
-                    console.log(inputValDelete.current)
                 } else {
                     inputValDelete.current = false;
                 }
@@ -266,8 +265,6 @@ const AutoComplete = ({
         return res;
     }, {});
 
-    console.log(groupedSuggestions)
-
     return (
         <Container
             inputHeight={
@@ -324,7 +321,6 @@ const AutoComplete = ({
                             );
                             handleSuggestionSelect(newSelectedSuggestion);
                         } else if (e.keyCode === DELETE_KEY && selectedCourses.size == 1) {
-                                console.log("test")
                                 inputValDelete.current = true;
                                 clearSelections();
 

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -253,27 +253,17 @@ const AutoComplete = ({
         const activity = obj.activity;
     
         if (res[`${courseName}-${midNum}`]) {
-            if (res[`${courseName}-${midNum}`][`${activity}`]) {
-                res[`${courseName}-${midNum}`][`${activity}`].push(obj);
+            if (res[`${courseName}-${midNum}`][activity]) {
+                res[`${courseName}-${midNum}`][activity].push(obj);
             } else {
-                res[`${courseName}-${midNum}`][`${activity}`] = [obj];
+                res[`${courseName}-${midNum}`][activity] = [obj];
             }
            
         } else {
-            res[`${courseName}-${midNum}`] = {}
-            res[`${courseName}-${midNum}`][`${activity}`] = [obj];
+            res[`${courseName}-${midNum}`] = {[activity]: [obj]};
         }
 
         return res;
-
-        // const [courseName, midNum, endNum] = obj.section_id.split("-");
-        // if (res[`${courseName}-${midNum}`]) {
-        //     res[`${courseName}-${midNum}`].push(obj);
-        // } else {
-        //     res[`${courseName}-${midNum}`] = [obj];
-        // }
-
-        // return res;
     }, {});
 
     console.log(groupedSuggestions)

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -220,8 +220,7 @@ const AutoComplete = ({
 
     // Create input text for bulk mode in the form of: [last selected section title] + [# selected courses - 1] more
     const generateCoursesValue = () => {
-        let lastElement;
-        for (lastElement of Array.from(selectedCourses));
+        const lastElement = Array.from(selectedCourses).pop()!;
         return `${lastElement.section_id} + ${selectedCourses.size - 1} more`;
     };
 

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -261,6 +261,18 @@ const AutoComplete = ({
 
             return res;
         }, {});
+    
+    /**
+     * Clear the input value and setValue
+     * @param newSelectedCourses - most up-to-date selected courses set
+     * @param suggestion - the section
+     */
+     const clearInputValue = () => {
+        if (inputRef.current) {
+            inputRef.current.value = "";
+            setValue("");
+        }
+    }
 
     return (
         <Container
@@ -346,7 +358,10 @@ const AutoComplete = ({
                     icon={faTimes}
                     hidden={!bulkMode}
                     parent={inputRef}
-                    onClick={() => clearSelections()}
+                    onClick={() => {
+                        clearSelections();
+                        clearInputValue();
+                    }}
                 />
             </AutoCompleteInputContainer>
             <DropdownContainer below={inputRef} hidden={!show}>
@@ -357,10 +372,10 @@ const AutoComplete = ({
                             courseCode={key}
                             value={value}
                             selectedCourses={selectedCourses}
-                            inputRef={inputRef}
                             setValue={setValue}
                             setTimeline={setTimeline}
                             setSelectedCourses={setSelectedCourses}
+                            clearInputValue={clearInputValue}
                         />
                     ))}
                 </DropdownBox>

--- a/frontend/alert/components/AutoComplete.tsx
+++ b/frontend/alert/components/AutoComplete.tsx
@@ -243,13 +243,17 @@ const AutoComplete = ({
     const [active, setActive] = useState(false);
     const [backdrop, setBackdrop] = useState("");
 
+    //active && suggestions.length > 0;
     const show = active && suggestions.length > 0;
+
+    const [selectedCourses, setSelectedCourses] = useState<Set<String>>(new Set())
 
     const setValue = (v) => {
         onValueChange(v);
         return setInternalValue(v);
     };
-
+   
+    //create placeholder -----------
     useEffect(() => {
         setBackdrop(
             generateBackdrop(inputRef.current && value, show && suggestions)
@@ -304,9 +308,16 @@ const AutoComplete = ({
         return res;
     }, {});
 
-    console.log(groupedSuggestions);
+    // console.log(groupedSuggestions);
+    useEffect(() => {
+        for (let course of Array.from(selectedCourses)) {
+            console.log(course)
+        }
+    }, [selectedCourses])
 
     return (
+        <>
+        {console.log("rerendered2")}
         <Container
             inputHeight={
                 inputRef.current
@@ -379,11 +390,12 @@ const AutoComplete = ({
                 <DropdownBox>
                     {Object.keys(groupedSuggestions).map(key => (
                         <GroupSuggestion sections={groupedSuggestions[key]} courseCode={key} value={value} 
-                        inputRef={inputRef} setActive={setActive} setValue={setValue} setTimeline={setTimeline}/>
+                        selectedCourses={selectedCourses} inputRef={inputRef} setActive={setActive} setValue={setValue} setTimeline={setTimeline} setSelectedCourses={setSelectedCourses}/>
                     ))}
                 </DropdownBox>
             </DropdownContainer>
         </Container>
+        </>
     );
 };
 

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -122,8 +122,11 @@ const Suggestion = ({
 }: SuggestionProps) => {
     const ref = useRef<HTMLDivElement>(null);
 
-    const [checked, setChecked] = useState(isChecked);
-    console.log(courseCode + ", " + checked);
+    const [checked, setChecked] = useState(() => isChecked);
+
+    useEffect(() => {
+        setChecked(isChecked);
+    }, [isChecked]);
 
     // If the suggestion becomes selected, make sure that it is
     // not fully or partially scrolled out of view
@@ -144,10 +147,15 @@ const Suggestion = ({
     }, [selected, ref]);
     return (
         <DropdownItemBox selected={selected} ref={ref}>
-            <CheckboxContainer onClick={() => setChecked(!checked)}>
+            <CheckboxContainer onClick={() => {
+                onClick();
+                setChecked(!checked)}}>
                 <Checkbox checked={checked}/>
             </CheckboxContainer>
-            <DropdownItemLeftCol onClick={onClick}>
+            <DropdownItemLeftCol onClick={() => {
+                onClick();
+                setChecked(!checked);
+            }}>
                 <SuggestionTitle>{courseCode}</SuggestionTitle>
                 <SuggestionSubtitle>{instructor ? instructor : "TBA"}</SuggestionSubtitle>
             </DropdownItemLeftCol>
@@ -162,13 +170,15 @@ interface GroupSuggestionProps {
     sections: Section[];
     courseCode: string;
     value: string;
+    selectedCourses: Set<String>;
     inputRef: React.RefObject<HTMLInputElement>;
     setActive: React.Dispatch<React.SetStateAction<boolean>>;
     setValue: (v: any) => void;
     setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
+    setSelectedCourses: any;
 }
 
-const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, setValue, setTimeline }: GroupSuggestionProps) => {
+const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRef, setActive, setValue, setTimeline, setSelectedCourses}: GroupSuggestionProps) => {
     const [allLectures, setAllLectures] = useState(false);
     const [allRecs, setAllRecs] = useState(false);
     const [allLabs, setAllLabs] = useState(false);
@@ -188,6 +198,7 @@ const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, set
     }
 
     const isChecked = (activity) => {
+        
         switch (activity) {
             case "LEC":
                 return allLectures;
@@ -227,8 +238,17 @@ const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, set
                             if (inputRef.current) {
                                 inputRef.current.value = suggestion.section_id;
                             }
-                            setActive(false);
+                            //setActive(false); dont close backdrop
                             setValue(suggestion.section_id);
+                            
+                            const newSelectedCourses = new Set(selectedCourses);
+                            if (selectedCourses.has(suggestion.section_id)) {
+                                newSelectedCourses.delete(suggestion.section_id);
+                            } else {
+                                newSelectedCourses.add(suggestion.section_id);
+                                
+                            }
+                            setSelectedCourses(newSelectedCourses);
                         }}
                         onChangeTimeline={() => {
                             setTimeline(suggestion.section_id);

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -177,10 +177,10 @@ interface GroupSuggestionProps {
     courseCode: string;
     value: string;
     selectedCourses: Set<Section>;
-    inputRef: React.RefObject<HTMLInputElement>;
     setValue: (v: any) => void;
     setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
     setSelectedCourses: React.Dispatch<React.SetStateAction<Set<Section>>>;
+    clearInputValue: () => void;
 }
 
 const GroupSuggestion = ({
@@ -188,10 +188,10 @@ const GroupSuggestion = ({
     courseCode,
     value,
     selectedCourses,
-    inputRef,
     setValue,
     setTimeline,
     setSelectedCourses,
+    clearInputValue,
 }: GroupSuggestionProps) => {
     const initializeButtonStates = () => {
         const states = {};
@@ -254,7 +254,7 @@ const GroupSuggestion = ({
         if (newSelectedCourses.size === 0) {
             clearInputValue();
         }
-        
+
         setSelectedCourses(newSelectedCourses);
     
     };
@@ -280,18 +280,6 @@ const GroupSuggestion = ({
         return newSelectedCourses
 
     };
-
-     /**
-     * Clear the input value and setValue
-     * @param newSelectedCourses - most up-to-date selected courses set
-     * @param suggestion - the section
-     */
-    const clearInputValue = () => {
-        if (inputRef.current) {
-            inputRef.current.value = "";
-            setValue("");
-        }
-    }
 
     return (
         <>

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faHistory } from "@fortawesome/free-solid-svg-icons";
+import { faBullseye, faHistory } from "@fortawesome/free-solid-svg-icons";
 
 import { Section } from "../types";
 import Checkbox from "./common/Checkbox"
@@ -182,9 +182,17 @@ interface GroupSuggestionProps {
 }
 
 const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRef, setValue, setTimeline, setSelectedCourses}: GroupSuggestionProps) => {
-    const [allLectures, setAllLectures] = useState(false);
-    const [allRecs, setAllRecs] = useState(false);
-    const [allLabs, setAllLabs] = useState(false);
+    
+    const initializeButtonStates = () => {
+        let states = {};
+        Object.keys(sections).map(key => {
+            states[key] = false;
+        })
+
+        return states;
+    }
+    
+    const [buttonStates, setButtonStates] = useState(initializeButtonStates)
 
      /**
      * Takes the activity/type of a section and return if all sections of {type} have been selected
@@ -193,19 +201,17 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
      */
     const selectedAllType = (type) => {
         //check if the user selected all courses of a certain type in a group suggestion
-        if (sections[type]) {
-            for (let section of sections[type]) {
-                if (!selectedCourses.has(section)) {
-                     syncButtonStates(type, false);
-                    return false;
-                }
+        let selectedAll = true;
+
+        sections[type].map(section => {
+            if (!selectedCourses.has(section)) {
+                selectedAll = false;
             }
+         })
 
-            syncButtonStates(type, true);
-        }
+        syncButtonStates(type, selectedAll);
+        return selectedAll;
 
-
-        return true;
     } 
 
     /**
@@ -215,46 +221,24 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
      */
     const syncButtonStates = (type, correctState) => {
         // update button state if its not the same as correctState
-        switch (type) {
-            case "LEC":
-                if (allLectures != correctState) {
-                    setAllLectures(correctState);
-                }
-                break;
-            case "REC":
-                if (allRecs != correctState) {
-                    setAllRecs(correctState);
-                }
-                break;
-            case "LAB":
-                if (allLabs != correctState) {
-                    setAllLabs(correctState);
-                }
-                break;
-            default:
-                break;
+        if (buttonStates[type] && buttonStates[type] != correctState) {
+            const newButtonStates = {...buttonStates};
+            newButtonStates[type] = correctState;
+            setButtonStates(newButtonStates);
         }
     }
     
      /**
-     * Takes the type of button clicked: LEC, REC, LABS and switch state
+     * Takes the type of button clicked: LEC, REC, LABS, etc and switch state
      * @param type - section activity
      */
     const toggleButton = (type) => {
-        switch(type) {
-            case 1:
-                setAllLectures(!allLectures);
-                syncCheckAlls("LEC", !allLectures, setSelectedCourses);
-                break;
-            case 2:
-                setAllRecs(!allRecs);
-                syncCheckAlls("REC", !allRecs, setSelectedCourses);
-                break;
-            case 3:
-                setAllLabs(!allLabs);
-                syncCheckAlls("LAB", !allLabs, setSelectedCourses);
-                break;
-        }
+        const newButtonStates = {...buttonStates};
+        
+        newButtonStates[type] = !newButtonStates[type];
+        syncCheckAlls(type, newButtonStates[type], setSelectedCourses);
+
+        setButtonStates(newButtonStates);
     }
 
     /**
@@ -308,7 +292,7 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
             </DropdownItemLeftCol>
             <ButtonContainer>
                 {Object.keys(sections).map((key, index) => (
-                    <ToggleButton toggled={selectedAllType(key)} onClick={() => toggleButton(index + 1)}>All {mapActivityToString(key).length > 0 ? mapActivityToString(key) : "Uncategorized"}</ToggleButton>
+                    <ToggleButton toggled={selectedAllType(key)} onClick={() => toggleButton(key)}>All {mapActivityToString(key).length > 0 ? mapActivityToString(key) : "Uncategorized"}</ToggleButton>
                 ))}
             </ButtonContainer>
         </DropdownItemBox>

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -1,0 +1,121 @@
+import React, { useState, useRef, useEffect } from "react";
+import styled from "styled-components";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faHistory } from "@fortawesome/free-solid-svg-icons";
+
+const DropdownItemBox = styled.div<{ selected: boolean }>`
+    border-bottom-style: solid;
+    border-width: 1px;
+    border-color: #d6d6d6;
+    padding-left: 0.5rem;
+    padding-bottom: 1rem;
+    display: flex;
+    justify-content: stretch;
+    flex-direction: row;
+    cursor: pointer;
+    ${(props) =>
+        props.selected ? "background-color: rgb(235, 235, 235);" : ""}
+    &:hover {
+        background-color: rgb(220, 220, 220);
+    }
+`;
+
+const DropdownItemLeftCol = styled.div`
+    max-width: 80%;
+    flex-basis: 80%;
+    flex-grow: 1;
+`;
+
+const SuggestionTitle = styled.div`
+    color: #282828;
+    font-size: 1rem;
+    font-family: "Inter", sans-serif;
+    font-weight: bold;
+    padding-top: 0.5rem;
+`;
+
+const SuggestionSubtitle = styled.div`
+    color: #282828;
+    font-size: 0.9rem;
+    padding-top: 0.4rem;
+    font-family: "Inter", sans-serif;
+`;
+
+const IconContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 1;
+    flex-basis: 20%;
+    font-size: 1.25rem;
+    color: #3baff7;
+`;
+
+interface SuggestionProps {
+    onClick: () => void;
+    onChangeTimeline: () => void;
+    courseCode: string;
+    title: string;
+    instructor: string;
+    selected: boolean;
+}
+
+const HistoryIcon = styled(FontAwesomeIcon)`
+    color: #c4c4c4;
+    &:hover {
+        color: #209cee;
+    }
+`;
+
+const Suggestion = ({
+    onClick,
+    onChangeTimeline,
+    courseCode,
+    title,
+    instructor,
+    selected,
+}: SuggestionProps) => {
+    const ref = useRef<HTMLDivElement>(null);
+    // If the suggestion becomes selected, make sure that it is
+    // not fully or partially scrolled out of view
+    useEffect(() => {
+        if (selected && ref.current && ref.current.parentElement) {
+            const { bottom, top } = ref.current.getBoundingClientRect();
+            const { parentElement } = ref.current;
+            const {
+                bottom: parentBottom,
+                top: parentTop,
+            } = parentElement.getBoundingClientRect();
+            if (bottom > parentBottom) {
+                parentElement.scrollBy({ top: bottom - parentBottom });
+            } else if (top < parentTop) {
+                parentElement.scrollBy({ top: top - parentTop });
+            }
+        }
+    }, [selected, ref]);
+    return (
+        <DropdownItemBox selected={selected} ref={ref}>
+            <DropdownItemLeftCol onClick={onClick}>
+                <SuggestionTitle>{courseCode}</SuggestionTitle>
+                <SuggestionSubtitle>{title}</SuggestionSubtitle>
+                <SuggestionSubtitle>{instructor}</SuggestionSubtitle>
+            </DropdownItemLeftCol>
+            <IconContainer onClick={onChangeTimeline}>
+                <HistoryIcon icon={faHistory} className="historyIcon" />
+            </IconContainer>
+        </DropdownItemBox>
+    );
+};
+
+const GroupSuggestion = () => {
+    return (
+        <div>
+
+        </div>
+    );
+}
+
+export default GroupSuggestion;
+

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -178,30 +178,61 @@ interface GroupSuggestionProps {
 }
 
 const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRef, setValue, setTimeline, setSelectedCourses}: GroupSuggestionProps) => {
-    
-    /**
+
+    const [allLectures, setAllLectures] = useState(false);
+    const [allRecs, setAllRecs] = useState(false);
+    const [allLabs, setAllLabs] = useState(false);
+
+     /**
      * Takes the activity/type of a section and return if all sections of {type} have been selected
      * Used to make sure to update button states when manually selecting each section
-     * @param type
+     * @param type - section activity
      */
-    //check if the user selected all courses of a certain type in a group suggestion
     const selectedAllType = (type) => {
+        //check if the user selected all courses of a certain type in a group suggestion
         for (let section of sections) {
             //selected course is the activity we are looking for & is in this group suggestion
             if (section.activity == type && !selectedCourses.has(section)) {
+                syncButtonStates(type, false);
                 return false;
             }
         }
         
         //all section of type are all selected then need to make sure states are in sync
-
+        syncButtonStates(type, true);
         return true;
     } 
 
-    const [allLectures, setAllLectures] = useState(() => selectedAllType("LEC"));
-    const [allRecs, setAllRecs] = useState(() => selectedAllType("REC"));
-    const [allLabs, setAllLabs] = useState(() => selectedAllType("LAB"));
+    /**
+     * Update button states to match selected courses in the case the user is manually checking/unchecking sections
+     * Ex. allLectures should be true when user manually select all "LEC" sections
+     * @param type - section activity
+     */
+    const syncButtonStates = (type, correctState) => {
+        // update button state if its not the same as correctState
+        switch (type) {
+            case "LEC":
+                if (allLectures != correctState) {
+                    setAllLectures(correctState);
+                }
+                break;
+            case "REC":
+                if (allRecs != correctState) {
+                    setAllRecs(correctState);
+                }
+                break;
+            case "LAB":
+                if (allLabs != correctState) {
+                    setAllLabs(correctState);
+                }
+                break;
+        }
+    }
     
+     /**
+     * Takes the type of button clicked: LEC, REC, LABS and switch state
+     * @param type - section activity
+     */
     const toggleButton = (type) => {
         switch(type) {
             case 1:
@@ -219,7 +250,12 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
         }
     }
 
-    //if one of the select all is toggled, update selected courses to match
+    /**
+     * If one of the select all is toggled, update selected courses to match
+     * @param type - section activity
+     * @param checked - whether the section is selected or not
+     * @param setSelectedCourses - method to update selected courses set
+     */
     const syncCheckAlls = (type, checked, setSelectedCourses) => {
         const newSelectedCourses = new Set(selectedCourses);
         sections.map((section) => {
@@ -235,7 +271,12 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
         setSelectedCourses(newSelectedCourses);
     }
 
-    //update the selected courses set when user check/uncheck box
+    /**
+     * Update the selected courses set when user check/uncheck box
+     * @param selectedCourses - selected courses set
+     * @param setSelectedCourses - method to update selected courses set
+     * @param setSelectedCourses - the section
+     */
     const updateSelectedCourses = (selectedCourses, setSelectedCourses, suggestion) => {
         const newSelectedCourses = new Set(selectedCourses);
         if (selectedCourses.has(suggestion)) {

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHistory } from "@fortawesome/free-solid-svg-icons";
 
 import { Section } from "../types";
+import Checkbox from "./common/Checkbox"
 
 interface DropdownItemBoxProps {
     selected?: boolean | false;
@@ -15,12 +16,12 @@ const DropdownItemBox = styled.div<DropdownItemBoxProps>`
     border-bottom-style: solid;
     border-width: 1px;
     border-color: #d6d6d6;
-    padding-left: ${(props) => props.headerBox ? "1rem" : "2rem"};
+    padding-left: 1rem;
     padding-top: 0.5rem;
     padding-bottom: 1rem;
     display: flex;
     justify-content: stretch;
-    flex-direction: ${(props) => props.headerBox ? "column" : "row"};;
+    flex-direction: ${(props) => props.headerBox ? "column" : "row"};
     cursor: pointer;
     ${(props) =>
         props.selected ? "background-color: rgb(235, 235, 235);" : ""}
@@ -33,8 +34,8 @@ const DropdownItemBox = styled.div<DropdownItemBoxProps>`
 `;
 
 const DropdownItemLeftCol = styled.div<{ headerBox?: boolean | false }>`
-    max-width: ${(props) => props.headerBox ? "100%" : "80%"};
-    flex-basis: ${(props) => props.headerBox ? "100%" : "80%"};
+    max-width: ${(props) => props.headerBox ? "100%" : "65%"};
+    flex-basis: ${(props) => props.headerBox ? "100%" : "65%"};
     flex-grow: 1;
 `;
 
@@ -63,6 +64,15 @@ const IconContainer = styled.div`
     font-size: 1.25rem;
     color: #3baff7;
 `;
+
+const CheckboxContainer = styled.div`
+    display: flex;
+    flex-direction: column; 
+    justify-content: center;
+    align-items: center;
+    flex-basis: 15%;
+    flex-grow: 1;
+`
 
 const ButtonContainer = styled.div`
     display: flex;
@@ -98,6 +108,7 @@ interface SuggestionProps {
     title: string;
     instructor: string;
     selected: boolean;
+    isChecked: boolean;
 }
 
 const Suggestion = ({
@@ -107,8 +118,13 @@ const Suggestion = ({
     title,
     instructor,
     selected,
+    isChecked,
 }: SuggestionProps) => {
     const ref = useRef<HTMLDivElement>(null);
+
+    const [checked, setChecked] = useState(isChecked);
+    console.log(courseCode + ", " + checked);
+
     // If the suggestion becomes selected, make sure that it is
     // not fully or partially scrolled out of view
     useEffect(() => {
@@ -128,6 +144,9 @@ const Suggestion = ({
     }, [selected, ref]);
     return (
         <DropdownItemBox selected={selected} ref={ref}>
+            <CheckboxContainer onClick={() => setChecked(!checked)}>
+                <Checkbox checked={checked}/>
+            </CheckboxContainer>
             <DropdownItemLeftCol onClick={onClick}>
                 <SuggestionTitle>{courseCode}</SuggestionTitle>
                 <SuggestionSubtitle>{instructor ? instructor : "TBA"}</SuggestionSubtitle>
@@ -168,8 +187,22 @@ const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, set
         }
     }
 
+    const isChecked = (activity) => {
+        switch (activity) {
+            case "LEC":
+                return allLectures;
+            case "REC":
+                return allRecs;
+            case "LAB":
+                return allLabs;
+            default:
+                return false;
+        }
+    }
+
     return (
         <>
+        {console.log("rerendered")}
         <DropdownItemBox headerBox={true}>
             <DropdownItemLeftCol headerBox={true}>
                 <SuggestionTitle>{courseCode}</SuggestionTitle>
@@ -202,6 +235,7 @@ const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, set
                         }}
                         title={suggestion.course_title}
                         instructor={suggestion.instructors[0]?.name}
+                        isChecked={isChecked(suggestion.activity)}
                     />
                 ))}
         </>

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -284,7 +284,7 @@ const GroupSuggestion = ({
                     </SuggestionSubtitle>
                 </DropdownItemLeftCol>
                 <ButtonContainer>
-                    {Object.keys(sections).map((key, index) => (
+                    {Object.keys(sections).map((key) => (
                         <ToggleButton
                             toggled={selectedAllActivity(key)}
                             onClick={() => toggleButton(key)}

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -20,12 +20,15 @@ const DropdownItemBox = styled.div<DropdownItemBoxProps>`
     padding-bottom: 1rem;
     display: flex;
     justify-content: stretch;
-    flex-direction: row;
+    flex-direction: ${(props) => props.headerBox ? "column" : "row"};;
     cursor: pointer;
     ${(props) =>
         props.selected ? "background-color: rgb(235, 235, 235);" : ""}
+
     &:hover {
-        background-color: rgb(220, 220, 220);
+        ${(props) =>
+            !props.headerBox ? "background-color: rgb(220, 220, 220);" : ""}
+        
     }
 `;
 
@@ -60,6 +63,26 @@ const IconContainer = styled.div`
     font-size: 1.25rem;
     color: #3baff7;
 `;
+
+const ButtonContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-grow: 1;
+    flex-basis: 100%;
+    margin-top: 8px;
+`
+
+const ToggleButton = styled.div<{ toggled: boolean }>`
+    border-radius: 18.5px;
+    border: 1px solid ${(props) => props.toggled ? "#5891FC" : "#D6D6D6"};
+    color: ${(props) => props.toggled ? "#5891FC" : "#7A848D"};
+    font-size: 12px;
+    background-color: ${(props) => props.toggled ? "#EBF2FF" : "#ffffff"};
+    padding: 4px 8px;
+    margin-right: 8px;
+`
+
 
 const HistoryIcon = styled(FontAwesomeIcon)`
     color: #c4c4c4;
@@ -127,6 +150,24 @@ interface GroupSuggestionProps {
 }
 
 const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, setValue, setTimeline }: GroupSuggestionProps) => {
+    const [allLectures, setAllLectures] = useState(false);
+    const [allRecs, setAllRecs] = useState(false);
+    const [allLabs, setAllLabs] = useState(false);
+
+    const toggleButton = (type) => {
+        switch(type) {
+            case 1:
+                setAllLectures(!allLectures);
+                break;
+            case 2:
+                setAllRecs(!allRecs);
+                break;
+            case 3:
+                setAllLabs(!allLabs);
+                break;
+        }
+    }
+
     return (
         <>
         <DropdownItemBox headerBox={true}>
@@ -134,6 +175,11 @@ const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, set
                 <SuggestionTitle>{courseCode}</SuggestionTitle>
                 <SuggestionSubtitle>{sections[0].course_title}</SuggestionSubtitle>
             </DropdownItemLeftCol>
+            <ButtonContainer>
+                <ToggleButton toggled={allLectures} onClick={() => toggleButton(1)}>All Lectures</ToggleButton>
+                <ToggleButton toggled={allRecs} onClick={() => toggleButton(2)}>All Recitations</ToggleButton>
+                <ToggleButton toggled={allLabs} onClick={() => toggleButton(3)}>All Labs</ToggleButton>
+            </ButtonContainer>
         </DropdownItemBox>
             {sections
                 .map((suggestion, index) => (

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -180,7 +180,8 @@ interface GroupSuggestionProps {
     inputRef: React.RefObject<HTMLInputElement>;
     setValue: (v: any) => void;
     setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
-    setSelectedCourses: any;
+    setSelectedCourses: React.Dispatch<React.SetStateAction<Set<Section>>>;
+    clearInput: () => void;
 }
 
 const GroupSuggestion = ({
@@ -192,6 +193,7 @@ const GroupSuggestion = ({
     setValue,
     setTimeline,
     setSelectedCourses,
+    clearInput,
 }: GroupSuggestionProps) => {
     const initializeButtonStates = () => {
         const states = {};
@@ -264,13 +266,22 @@ const GroupSuggestion = ({
         selectedCourses,
         suggestion
     ) => {
-        const newSelectedCourses = new Set(selectedCourses);
+        const newSelectedCourses: Set<Section> = new Set(selectedCourses);
         if (selectedCourses.has(suggestion)) {
             newSelectedCourses.delete(suggestion);
         } else {
             newSelectedCourses.add(suggestion);
         }
+
+        // If the only selected courses is deselected then clear input value
+        if (newSelectedCourses.size === 0 && inputRef.current) {
+            console.log("test")
+            inputRef.current.value = "";
+            setValue("");
+        }
+
         setSelectedCourses(newSelectedCourses);
+
     };
 
     return (

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -6,6 +6,7 @@ import { faHistory } from "@fortawesome/free-solid-svg-icons";
 
 import { Section } from "../types";
 import Checkbox from "./common/Checkbox"
+import userEvent from "@testing-library/user-event";
 
 interface DropdownItemBoxProps {
     selected?: boolean | false;

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -4,11 +4,19 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHistory } from "@fortawesome/free-solid-svg-icons";
 
-const DropdownItemBox = styled.div<{ selected: boolean }>`
+import { Section } from "../types";
+
+interface DropdownItemBoxProps {
+    selected?: boolean | false;
+    headerBox?: boolean | false;
+}
+
+const DropdownItemBox = styled.div<DropdownItemBoxProps>`
     border-bottom-style: solid;
     border-width: 1px;
     border-color: #d6d6d6;
-    padding-left: 0.5rem;
+    padding-left: ${(props) => props.headerBox ? "1rem" : "2rem"};
+    padding-top: 0.5rem;
     padding-bottom: 1rem;
     display: flex;
     justify-content: stretch;
@@ -21,9 +29,9 @@ const DropdownItemBox = styled.div<{ selected: boolean }>`
     }
 `;
 
-const DropdownItemLeftCol = styled.div`
-    max-width: 80%;
-    flex-basis: 80%;
+const DropdownItemLeftCol = styled.div<{ headerBox?: boolean | false }>`
+    max-width: ${(props) => props.headerBox ? "100%" : "80%"};
+    flex-basis: ${(props) => props.headerBox ? "100%" : "80%"};
     flex-grow: 1;
 `;
 
@@ -53,6 +61,13 @@ const IconContainer = styled.div`
     color: #3baff7;
 `;
 
+const HistoryIcon = styled(FontAwesomeIcon)`
+    color: #c4c4c4;
+    &:hover {
+        color: #209cee;
+    }
+`;
+
 interface SuggestionProps {
     onClick: () => void;
     onChangeTimeline: () => void;
@@ -61,13 +76,6 @@ interface SuggestionProps {
     instructor: string;
     selected: boolean;
 }
-
-const HistoryIcon = styled(FontAwesomeIcon)`
-    color: #c4c4c4;
-    &:hover {
-        color: #209cee;
-    }
-`;
 
 const Suggestion = ({
     onClick,
@@ -99,8 +107,7 @@ const Suggestion = ({
         <DropdownItemBox selected={selected} ref={ref}>
             <DropdownItemLeftCol onClick={onClick}>
                 <SuggestionTitle>{courseCode}</SuggestionTitle>
-                <SuggestionSubtitle>{title}</SuggestionSubtitle>
-                <SuggestionSubtitle>{instructor}</SuggestionSubtitle>
+                <SuggestionSubtitle>{instructor ? instructor : "TBA"}</SuggestionSubtitle>
             </DropdownItemLeftCol>
             <IconContainer onClick={onChangeTimeline}>
                 <HistoryIcon icon={faHistory} className="historyIcon" />
@@ -109,13 +116,50 @@ const Suggestion = ({
     );
 };
 
-const GroupSuggestion = () => {
-    return (
-        <div>
-
-        </div>
-    );
+interface GroupSuggestionProps {
+    sections: Section[];
+    courseCode: string;
+    value: string;
+    inputRef: React.RefObject<HTMLInputElement>;
+    setActive: React.Dispatch<React.SetStateAction<boolean>>;
+    setValue: (v: any) => void;
+    setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
-export default GroupSuggestion;
+const GroupSuggestion = ({ sections, courseCode, value, inputRef, setActive, setValue, setTimeline }: GroupSuggestionProps) => {
+    return (
+        <>
+        <DropdownItemBox headerBox={true}>
+            <DropdownItemLeftCol headerBox={true}>
+                <SuggestionTitle>{courseCode}</SuggestionTitle>
+                <SuggestionSubtitle>{sections[0].course_title}</SuggestionSubtitle>
+            </DropdownItemLeftCol>
+        </DropdownItemBox>
+            {sections
+                .map((suggestion, index) => (
+                    <Suggestion
+                        key={suggestion.section_id}
+                        selected={
+                            suggestion.section_id.toLowerCase() ===
+                            value.toLowerCase()
+                        }
+                        courseCode={suggestion.section_id}
+                        onClick={() => {
+                            if (inputRef.current) {
+                                inputRef.current.value = suggestion.section_id;
+                            }
+                            setActive(false);
+                            setValue(suggestion.section_id);
+                        }}
+                        onChangeTimeline={() => {
+                            setTimeline(suggestion.section_id);
+                        }}
+                        title={suggestion.course_title}
+                        instructor={suggestion.instructors[0]?.name}
+                    />
+                ))}
+        </>
+    );
+};
 
+export default GroupSuggestion;

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -181,7 +181,6 @@ interface GroupSuggestionProps {
     setValue: (v: any) => void;
     setTimeline: React.Dispatch<React.SetStateAction<string | null>>;
     setSelectedCourses: React.Dispatch<React.SetStateAction<Set<Section>>>;
-    clearInput: () => void;
 }
 
 const GroupSuggestion = ({
@@ -193,7 +192,6 @@ const GroupSuggestion = ({
     setValue,
     setTimeline,
     setSelectedCourses,
-    clearInput,
 }: GroupSuggestionProps) => {
     const initializeButtonStates = () => {
         const states = {};
@@ -252,7 +250,11 @@ const GroupSuggestion = ({
         const newSelectedCourses = new Set(selectedCourses);
 
         sections[activity].forEach(section => checkedAll ? newSelectedCourses.add(section) : newSelectedCourses.delete(section));
-
+        
+        if (newSelectedCourses.size === 0) {
+            clearInputValue();
+        }
+        
         setSelectedCourses(newSelectedCourses);
     
     };
@@ -273,16 +275,23 @@ const GroupSuggestion = ({
             newSelectedCourses.add(suggestion);
         }
 
-        // If the only selected courses is deselected then clear input value
-        if (newSelectedCourses.size === 0 && inputRef.current) {
-            console.log("test")
+        setSelectedCourses(newSelectedCourses);
+
+        return newSelectedCourses
+
+    };
+
+     /**
+     * Clear the input value and setValue
+     * @param newSelectedCourses - most up-to-date selected courses set
+     * @param suggestion - the section
+     */
+    const clearInputValue = () => {
+        if (inputRef.current) {
             inputRef.current.value = "";
             setValue("");
         }
-
-        setSelectedCourses(newSelectedCourses);
-
-    };
+    }
 
     return (
         <>
@@ -318,17 +327,19 @@ const GroupSuggestion = ({
                         }
                         courseCode={suggestion.section_id}
                         onClick={() => {
-                            updateSelectedCourses(
+                            const newSelectedCourses = updateSelectedCourses(
                                 selectedCourses,
                                 suggestion
                             );
-
-                            // show the selected course name only if not in bulk mode
-                            if (inputRef.current && selectedCourses.size <= 1) {
-                                inputRef.current.value = suggestion.section_id;
+                            
+                            //update suggestion value
+                            if (newSelectedCourses.size >= 1) {
+                                setValue(suggestion.section_id)
+                            } else {
+                                clearInputValue();
                             }
 
-                            setValue(suggestion.section_id);
+
                         }}
                         onChangeTimeline={() => {
                             setTimeline(suggestion.section_id);

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -195,21 +195,21 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
     const [buttonStates, setButtonStates] = useState(initializeButtonStates)
 
      /**
-     * Takes the activity/type of a section and return if all sections of {type} have been selected
+     * Takes the activity/activity of a section and return if all sections of {activity} have been selected
      * Used to make sure to update button states when manually selecting each section
-     * @param type - section activity
+     * @param activity - section activity
      */
-    const selectedAllType = (type) => {
-        //check if the user selected all courses of a certain type in a group suggestion
+    const selectedAllactivity = (activity) => {
+        //check if the user selected all courses of a certain activity in a group suggestion
         let selectedAll = true;
 
-        sections[type].map(section => {
+        sections[activity].map(section => {
             if (!selectedCourses.has(section)) {
                 selectedAll = false;
             }
          })
 
-        syncButtonStates(type, selectedAll);
+        syncButtonStates(activity, selectedAll);
         return selectedAll;
 
     } 
@@ -217,41 +217,41 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
     /**
      * Update button states to match selected courses in the case the user is manually checking/unchecking sections
      * Ex. allLectures should be true when user manually select all "LEC" sections
-     * @param type - section activity
+     * @param activity - section activity
      */
-    const syncButtonStates = (type, correctState) => {
+    const syncButtonStates = (activity, correctState) => {
         // update button state if its not the same as correctState
-        if (buttonStates[type] && buttonStates[type] != correctState) {
+        if (buttonStates[activity] && buttonStates[activity] != correctState) {
             const newButtonStates = {...buttonStates};
-            newButtonStates[type] = correctState;
+            newButtonStates[activity] = correctState;
             setButtonStates(newButtonStates);
         }
     }
     
      /**
-     * Takes the type of button clicked: LEC, REC, LABS, etc and switch state
-     * @param type - section activity
+     * Takes the activity of button clicked: LEC, REC, LABS, etc and switch state
+     * @param activity - section activity
      */
-    const toggleButton = (type) => {
+    const toggleButton = (activity) => {
         const newButtonStates = {...buttonStates};
         
-        newButtonStates[type] = !newButtonStates[type];
-        syncCheckAlls(type, newButtonStates[type], setSelectedCourses);
+        newButtonStates[activity] = !newButtonStates[activity];
+        syncCheckAlls(activity, newButtonStates[activity], setSelectedCourses);
 
         setButtonStates(newButtonStates);
     }
 
     /**
      * If one of the select all is toggled, update selected courses to match
-     * @param type - section activity
-     * @param checkedAll - whether all sections of type should be checked or not
+     * @param activity - section activity
+     * @param checkedAll - whether all sections of activity should be checked or not
      * @param setSelectedCourses - method to update selected courses set
      */
-    const syncCheckAlls = (type, checkedAll, setSelectedCourses) => {
+    const syncCheckAlls = (activity, checkedAll, setSelectedCourses) => {
         const newSelectedCourses = new Set(selectedCourses);
         
-        if (sections[type]) {
-            sections[type].map((section) => {
+        if (sections[activity]) {
+            sections[activity].map((section) => {
                 //checkedAll = false but selectedCourses has course
                 if (newSelectedCourses.has(section) && !checkedAll) {
                     newSelectedCourses.delete(section)
@@ -292,7 +292,7 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
             </DropdownItemLeftCol>
             <ButtonContainer>
                 {Object.keys(sections).map((key, index) => (
-                    <ToggleButton toggled={selectedAllType(key)} onClick={() => toggleButton(key)}>All {mapActivityToString(key).length > 0 ? mapActivityToString(key) : "Uncategorized"}</ToggleButton>
+                    <ToggleButton toggled={selectedAllactivity(key)} onClick={() => toggleButton(key)}>All {mapActivityToString(key).length > 0 ? mapActivityToString(key) : "Uncategorized"}</ToggleButton>
                 ))}
             </ButtonContainer>
         </DropdownItemBox>

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -205,19 +205,13 @@ const GroupSuggestion = ({
     const [buttonStates, setButtonStates] = useState(initializeButtonStates);
 
     /**
-     * Takes the activity/activity of a section and return if all sections of {activity} have been selected
+     * Takes the activity of a section and return if all sections of {activity} have been selected
      * Used to make sure to update button states when manually selecting each section
      * @param activity - section activity
      */
     const selectedAllActivity = (activity) => {
         // check if the user selected all courses of a certain activity in a group suggestion
-        let selectedAll = true;
-
-        sections[activity].map((section) => {
-            if (!selectedCourses.has(section)) {
-                selectedAll = false;
-            }
-        });
+        const selectedAll = sections[activity].every((section) => selectedCourses.has(section));
 
         syncButtonStates(activity, selectedAll);
         return selectedAll;
@@ -230,7 +224,7 @@ const GroupSuggestion = ({
      */
     const syncButtonStates = (activity, correctState) => {
         // update button state if its not the same as correctState
-        if (buttonStates[activity] != correctState) {
+        if (buttonStates[activity] !== correctState) {
             const newButtonStates = { ...buttonStates };
             newButtonStates[activity] = correctState;
             setButtonStates(newButtonStates);
@@ -242,47 +236,32 @@ const GroupSuggestion = ({
      * @param activity - section activity
      */
     const toggleButton = (activity) => {
-        const newButtonStates = { ...buttonStates };
-
-        newButtonStates[activity] = !newButtonStates[activity];
-        syncCheckAlls(activity, newButtonStates[activity], setSelectedCourses);
-
-        setButtonStates(newButtonStates);
+        const newState = !buttonStates[activity];
+        syncButtonStates(activity, newState);
+        syncCheckAlls(activity, newState);
     };
 
     /**
      * If one of the select all is toggled, update selected courses to match
      * @param activity - section activity
      * @param checkedAll - whether all sections of activity should be checked or not
-     * @param setSelectedCourses - method to update selected courses set
      */
-    const syncCheckAlls = (activity, checkedAll, setSelectedCourses) => {
+    const syncCheckAlls = (activity, checkedAll) => {
         const newSelectedCourses = new Set(selectedCourses);
 
-        if (sections[activity]) {
-            sections[activity].map((section) => {
-                // checkedAll = false but selectedCourses has course
-                if (newSelectedCourses.has(section) && !checkedAll) {
-                    newSelectedCourses.delete(section);
+        sections[activity].forEach(section => checkedAll ? newSelectedCourses.add(section) : newSelectedCourses.delete(section));
 
-                    // checkedAll = true but selectedCourses doesn't have course
-                } else if (!newSelectedCourses.has(section) && checkedAll) {
-                    newSelectedCourses.add(section);
-                }
-            });
-            setSelectedCourses(newSelectedCourses);
-        }
+        setSelectedCourses(newSelectedCourses);
+    
     };
 
     /**
      * Update the selected courses set when user check/uncheck box
      * @param selectedCourses - selected courses set
-     * @param setSelectedCourses - method to update selected courses set
-     * @param setSelectedCourses - the section
+     * @param suggestion - the section
      */
     const updateSelectedCourses = (
         selectedCourses,
-        setSelectedCourses,
         suggestion
     ) => {
         const newSelectedCourses = new Set(selectedCourses);
@@ -330,7 +309,6 @@ const GroupSuggestion = ({
                         onClick={() => {
                             updateSelectedCourses(
                                 selectedCourses,
-                                setSelectedCourses,
                                 suggestion
                             );
 

--- a/frontend/alert/components/GroupSuggestion.tsx
+++ b/frontend/alert/components/GroupSuggestion.tsx
@@ -4,10 +4,10 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBullseye, faHistory } from "@fortawesome/free-solid-svg-icons";
 
-import { Section } from "../types";
-import Checkbox from "./common/Checkbox"
 import userEvent from "@testing-library/user-event";
-import { mapActivityToString } from "../util"
+import { Section } from "../types";
+import Checkbox from "./common/Checkbox";
+import { mapActivityToString } from "../util";
 
 interface DropdownItemBoxProps {
     selected?: boolean | false;
@@ -23,7 +23,7 @@ const DropdownItemBox = styled.div<DropdownItemBoxProps>`
     padding-bottom: 1rem;
     display: flex;
     justify-content: stretch;
-    flex-direction: ${(props) => props.headerBox ? "column" : "row"};
+    flex-direction: ${(props) => (props.headerBox ? "column" : "row")};
     cursor: pointer;
     ${(props) =>
         props.selected ? "background-color: rgb(235, 235, 235);" : ""}
@@ -31,13 +31,12 @@ const DropdownItemBox = styled.div<DropdownItemBoxProps>`
     &:hover {
         ${(props) =>
             !props.headerBox ? "background-color: rgb(220, 220, 220);" : ""}
-        
     }
 `;
 
 const DropdownItemLeftCol = styled.div<{ headerBox?: boolean | false }>`
-    max-width: ${(props) => props.headerBox ? "100%" : "65%"};
-    flex-basis: ${(props) => props.headerBox ? "100%" : "65%"};
+    max-width: ${(props) => (props.headerBox ? "100%" : "65%")};
+    flex-basis: ${(props) => (props.headerBox ? "100%" : "65%")};
     flex-grow: 1;
 `;
 
@@ -69,12 +68,12 @@ const IconContainer = styled.div`
 
 const CheckboxContainer = styled.div`
     display: flex;
-    flex-direction: column; 
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     flex-basis: 15%;
     flex-grow: 1;
-`
+`;
 
 const ButtonContainer = styled.div`
     display: flex;
@@ -83,18 +82,17 @@ const ButtonContainer = styled.div`
     flex-grow: 1;
     flex-basis: 100%;
     margin-top: 8px;
-`
+`;
 
 const ToggleButton = styled.div<{ toggled: boolean }>`
     border-radius: 18.5px;
-    border: 1px solid ${(props) => props.toggled ? "#5891FC" : "#D6D6D6"};
-    color: ${(props) => props.toggled ? "#5891FC" : "#7A848D"};
+    border: 1px solid ${(props) => (props.toggled ? "#5891FC" : "#D6D6D6")};
+    color: ${(props) => (props.toggled ? "#5891FC" : "#7A848D")};
     font-size: 12px;
-    background-color: ${(props) => props.toggled ? "#EBF2FF" : "#ffffff"};
+    background-color: ${(props) => (props.toggled ? "#EBF2FF" : "#ffffff")};
     padding: 4px 8px;
     margin-right: 8px;
-`
-
+`;
 
 const HistoryIcon = styled(FontAwesomeIcon)`
     color: #c4c4c4;
@@ -149,19 +147,23 @@ const Suggestion = ({
     }, [selected, ref]);
 
     return (
-        
         <DropdownItemBox selected={selected} ref={ref}>
-            <CheckboxContainer onClick={() => {
-                onClick();
-                setChecked(!checked)}}>
-                <Checkbox checked={checked}/>
+            <CheckboxContainer
+                onClick={() => {
+                    onClick();
+                    setChecked(!checked);
+                }}
+            >
+                <Checkbox checked={checked} />
             </CheckboxContainer>
-            <DropdownItemLeftCol onClick={() => {
-                onClick();
-                setChecked(!checked);
-            }}>
+            <DropdownItemLeftCol
+                onClick={() => {
+                    onClick();
+                    setChecked(!checked);
+                }}
+            >
                 <SuggestionTitle>{courseCode}</SuggestionTitle>
-                <SuggestionSubtitle>{instructor ? instructor : "TBA"}</SuggestionSubtitle>
+                <SuggestionSubtitle>{instructor || "TBA"}</SuggestionSubtitle>
             </DropdownItemLeftCol>
             <IconContainer onClick={onChangeTimeline}>
                 <HistoryIcon icon={faHistory} className="historyIcon" />
@@ -181,38 +183,45 @@ interface GroupSuggestionProps {
     setSelectedCourses: any;
 }
 
-const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRef, setValue, setTimeline, setSelectedCourses}: GroupSuggestionProps) => {
-    
+const GroupSuggestion = ({
+    sections,
+    courseCode,
+    value,
+    selectedCourses,
+    inputRef,
+    setValue,
+    setTimeline,
+    setSelectedCourses,
+}: GroupSuggestionProps) => {
     const initializeButtonStates = () => {
-        let states = {};
-        Object.keys(sections).map(key => {
+        const states = {};
+        Object.keys(sections).map((key) => {
             states[key] = false;
-        })
+        });
 
         return states;
-    }
-    
-    const [buttonStates, setButtonStates] = useState(initializeButtonStates)
+    };
 
-     /**
+    const [buttonStates, setButtonStates] = useState(initializeButtonStates);
+
+    /**
      * Takes the activity/activity of a section and return if all sections of {activity} have been selected
      * Used to make sure to update button states when manually selecting each section
      * @param activity - section activity
      */
-    const selectedAllactivity = (activity) => {
-        //check if the user selected all courses of a certain activity in a group suggestion
+    const selectedAllActivity = (activity) => {
+        // check if the user selected all courses of a certain activity in a group suggestion
         let selectedAll = true;
 
-        sections[activity].map(section => {
+        sections[activity].map((section) => {
             if (!selectedCourses.has(section)) {
                 selectedAll = false;
             }
-         })
+        });
 
         syncButtonStates(activity, selectedAll);
         return selectedAll;
-
-    } 
+    };
 
     /**
      * Update button states to match selected courses in the case the user is manually checking/unchecking sections
@@ -221,25 +230,25 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
      */
     const syncButtonStates = (activity, correctState) => {
         // update button state if its not the same as correctState
-        if (buttonStates[activity] && buttonStates[activity] != correctState) {
-            const newButtonStates = {...buttonStates};
+        if (buttonStates[activity] != correctState) {
+            const newButtonStates = { ...buttonStates };
             newButtonStates[activity] = correctState;
             setButtonStates(newButtonStates);
         }
-    }
-    
-     /**
+    };
+
+    /**
      * Takes the activity of button clicked: LEC, REC, LABS, etc and switch state
      * @param activity - section activity
      */
     const toggleButton = (activity) => {
-        const newButtonStates = {...buttonStates};
-        
+        const newButtonStates = { ...buttonStates };
+
         newButtonStates[activity] = !newButtonStates[activity];
         syncCheckAlls(activity, newButtonStates[activity], setSelectedCourses);
 
         setButtonStates(newButtonStates);
-    }
+    };
 
     /**
      * If one of the select all is toggled, update selected courses to match
@@ -249,22 +258,21 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
      */
     const syncCheckAlls = (activity, checkedAll, setSelectedCourses) => {
         const newSelectedCourses = new Set(selectedCourses);
-        
+
         if (sections[activity]) {
             sections[activity].map((section) => {
-                //checkedAll = false but selectedCourses has course
+                // checkedAll = false but selectedCourses has course
                 if (newSelectedCourses.has(section) && !checkedAll) {
-                    newSelectedCourses.delete(section)
-                
-                //checkedAll = true but selectedCourses doesn't have course
+                    newSelectedCourses.delete(section);
+
+                    // checkedAll = true but selectedCourses doesn't have course
                 } else if (!newSelectedCourses.has(section) && checkedAll) {
-                    newSelectedCourses.add(section)
-                } 
-            })
+                    newSelectedCourses.add(section);
+                }
+            });
             setSelectedCourses(newSelectedCourses);
         }
-        
-    }
+    };
 
     /**
      * Update the selected courses set when user check/uncheck box
@@ -272,7 +280,11 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
      * @param setSelectedCourses - method to update selected courses set
      * @param setSelectedCourses - the section
      */
-    const updateSelectedCourses = (selectedCourses, setSelectedCourses, suggestion) => {
+    const updateSelectedCourses = (
+        selectedCourses,
+        setSelectedCourses,
+        suggestion
+    ) => {
         const newSelectedCourses = new Set(selectedCourses);
         if (selectedCourses.has(suggestion)) {
             newSelectedCourses.delete(suggestion);
@@ -280,24 +292,34 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
             newSelectedCourses.add(suggestion);
         }
         setSelectedCourses(newSelectedCourses);
-       
-    }
+    };
 
     return (
         <>
-        <DropdownItemBox headerBox={true}>
-            <DropdownItemLeftCol headerBox={true}>
-                <SuggestionTitle>{courseCode}</SuggestionTitle>
-                <SuggestionSubtitle>{sections[Object.keys(sections)[0]].length > 0 && sections[Object.keys(sections)[0]][0].course_title}</SuggestionSubtitle>
-            </DropdownItemLeftCol>
-            <ButtonContainer>
-                {Object.keys(sections).map((key, index) => (
-                    <ToggleButton toggled={selectedAllactivity(key)} onClick={() => toggleButton(key)}>All {mapActivityToString(key).length > 0 ? mapActivityToString(key) : "Uncategorized"}</ToggleButton>
-                ))}
-            </ButtonContainer>
-        </DropdownItemBox>
-            {Object.keys(sections).map(key => (
-                sections[key].map(suggestion => (
+            <DropdownItemBox headerBox={true}>
+                <DropdownItemLeftCol headerBox={true}>
+                    <SuggestionTitle>{courseCode}</SuggestionTitle>
+                    <SuggestionSubtitle>
+                        {sections[Object.keys(sections)[0]].length > 0 &&
+                            sections[Object.keys(sections)[0]][0].course_title}
+                    </SuggestionSubtitle>
+                </DropdownItemLeftCol>
+                <ButtonContainer>
+                    {Object.keys(sections).map((key, index) => (
+                        <ToggleButton
+                            toggled={selectedAllActivity(key)}
+                            onClick={() => toggleButton(key)}
+                        >
+                            All{" "}
+                            {mapActivityToString(key).length > 0
+                                ? mapActivityToString(key)
+                                : "Uncategorized"}
+                        </ToggleButton>
+                    ))}
+                </ButtonContainer>
+            </DropdownItemBox>
+            {Object.keys(sections).map((key) =>
+                sections[key].map((suggestion) => (
                     <Suggestion
                         key={suggestion.section_id}
                         selected={
@@ -306,15 +328,18 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
                         }
                         courseCode={suggestion.section_id}
                         onClick={() => {
-                            updateSelectedCourses(selectedCourses, setSelectedCourses, suggestion);
+                            updateSelectedCourses(
+                                selectedCourses,
+                                setSelectedCourses,
+                                suggestion
+                            );
 
-                            //show the selected course name only if not in bulk mode
+                            // show the selected course name only if not in bulk mode
                             if (inputRef.current && selectedCourses.size <= 1) {
                                 inputRef.current.value = suggestion.section_id;
                             }
 
                             setValue(suggestion.section_id);
-                           
                         }}
                         onChangeTimeline={() => {
                             setTimeline(suggestion.section_id);
@@ -323,8 +348,8 @@ const GroupSuggestion = ({ sections, courseCode, value, selectedCourses, inputRe
                         instructor={suggestion.instructors[0]?.name}
                         isChecked={selectedCourses.has(suggestion)}
                     />
-                ))  
-            ))}
+                ))
+            )}
         </>
     );
 };

--- a/frontend/alert/components/Timeline/TimelineElement.tsx
+++ b/frontend/alert/components/Timeline/TimelineElement.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircle } from "@fortawesome/free-solid-svg-icons";
 
-//const to calculate segment length
+// const to calculate segment length
 const MIN_SEGMENT_LENGTH = 20;
 const MAX_SEGMENT_LENGTH = 250;
 const MULTIPLIER = 18;
@@ -50,9 +50,9 @@ const convertTime = (timeString) => {
     /* Convert time string to array with MM/DD as
      * the first element and HR:MIN pm/am as the second
      */
-    let d = new Date(timeString);
+    const d = new Date(timeString);
 
-    //format: ["MM:DD", "HR:MIN pm/am"]
+    // format: ["MM:DD", "HR:MIN pm/am"]
     return [
         d.toLocaleDateString("en-US", { month: "numeric", day: "numeric" }),
         d
@@ -66,7 +66,7 @@ const convertTime = (timeString) => {
 };
 
 const timeInHours = (timeString) => {
-    let d = new Date(timeString);
+    const d = new Date(timeString);
     return d.getHours();
 };
 
@@ -87,8 +87,8 @@ interface TimelineElementProps {
 }
 
 const TimelineElement = ({ courseStatusData, index }: TimelineElementProps) => {
-    const prevTime = courseStatusData[index - 1][0]["created_at"];
-    const currTime = courseStatusData[index][0]["created_at"];
+    const prevTime = courseStatusData[index - 1][0].created_at;
+    const currTime = courseStatusData[index][0].created_at;
     const segLength = calcSegmentLength(prevTime, currTime);
 
     // second index is formatted differently (time info on circle layer) than rest
@@ -109,12 +109,12 @@ const TimelineElement = ({ courseStatusData, index }: TimelineElementProps) => {
                 </>
             ) : (
                 <>
-                    <div></div>
+                    <div />
                     <Segment
                         open={courseStatusData[index - 1][1] == "opened"}
                         length={segLength}
                     />
-                    <div></div>
+                    <div />
                 </>
             )}
 

--- a/frontend/alert/components/Timeline/index.tsx
+++ b/frontend/alert/components/Timeline/index.tsx
@@ -137,7 +137,7 @@ const TimelineContainer = styled.div`
 `;
 
 const getMonthDay = (timeString) => {
-    let d = new Date(timeString);
+    const d = new Date(timeString);
     return d.toLocaleDateString("en-US", { month: "numeric", day: "numeric" });
 };
 
@@ -146,17 +146,16 @@ const formatData = (courseData) => {
      * length 3 arrays with the status data object, the current status at each created_at data point
      * and if the date is different
      */
-    let formattedData = courseData.reduce((ans, item, index) => {
+    const formattedData = courseData.reduce((ans, item, index) => {
         const sameDate =
             index == 0 ||
-            getMonthDay(courseData[index]["created_at"]) ==
-                getMonthDay(courseData[index - 1]["created_at"]);
+            getMonthDay(courseData[index].created_at) ==
+                getMonthDay(courseData[index - 1].created_at);
 
-        if (item["old_status"] == "C" && item["new_status"] == "O") {
+        if (item.old_status == "C" && item.new_status == "O") {
             return ans.concat([[item, "opened", sameDate]]);
-        } else {
-            return ans.concat([[item, "closed", sameDate]]);
         }
+        return ans.concat([[item, "closed", sameDate]]);
     }, []);
 
     return formattedData;
@@ -174,14 +173,14 @@ const Timeline = ({ courseCode, setTimeline }: TimelineProps) => {
 
     const close = !courseCode;
 
-    //There is data if its loaded & courseStatusData is not null & not empty
+    // There is data if its loaded & courseStatusData is not null & not empty
     const isDataNotEmpty =
         loaded && courseStatusData && courseStatusData.length > 0;
 
-    //hook that detects when a user is scrolling a component & when they stop scrolling
+    // hook that detects when a user is scrolling a component & when they stop scrolling
     const useOnScroll = (ref) => {
         useEffect(() => {
-            var timer;
+            let timer;
             const handleScroll = (e) => {
                 if (!scrollTimeline) {
                     setScrollTimeline(true);
@@ -198,7 +197,7 @@ const Timeline = ({ courseCode, setTimeline }: TimelineProps) => {
         return ref;
     };
 
-    //hook that detects if user click outside, but not history icon, of the alert pane
+    // hook that detects if user click outside, but not history icon, of the alert pane
     const onClickOutside = useOnClickOutside(
         () => {
             setTimeline(null);
@@ -215,12 +214,12 @@ const Timeline = ({ courseCode, setTimeline }: TimelineProps) => {
             return;
         }
 
-        //loading course status update data
+        // loading course status update data
         setLoaded(false);
 
         fetch(`/api/base/statusupdate/${courseCode}/`).then((res) =>
             res.json().then((courseResult) => {
-                //sort data by when it was created from earliest to latest
+                // sort data by when it was created from earliest to latest
                 courseResult.sort((a, b) =>
                     a.created_at < b.created_at ? 1 : -1
                 );

--- a/frontend/alert/components/common/Checkbox.tsx
+++ b/frontend/alert/components/common/Checkbox.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import styled from "styled-components"
+
+import { faCheckSquare, faSquare } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface IconContainerProps {
+    checked: boolean;
+}
+const IconContainer = styled.div<IconContainerProps>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    color: #489BE8;
+    width: 1rem;
+    height: 1rem;
+
+    ${(props) =>
+        !props.checked ? "border: 1px solid #7A848D" : "border: none"}
+`
+
+
+interface CheckboxProps {
+    checked: boolean;
+}
+
+const Checkbox = ({checked}: CheckboxProps) => {
+
+    return (
+        <div
+            aria-checked="false"
+            role="checkbox"
+            style={{
+                flexGrow: 0,
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                display: "flex",
+                fontSize: "18px",
+            }}
+        >
+            <IconContainer checked={checked}>
+                {checked && <FontAwesomeIcon icon={faCheckSquare}></FontAwesomeIcon>}
+            </IconContainer>
+        </div>
+    );
+}
+
+export default Checkbox;

--- a/frontend/alert/components/common/Checkbox.tsx
+++ b/frontend/alert/components/common/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components"
+import styled from "styled-components";
 
 import { faCheckSquare, faSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -12,21 +12,19 @@ const IconContainer = styled.div<IconContainerProps>`
     align-items: center;
     justify-content: center;
     font-size: 1.25rem;
-    color: #489BE8;
+    color: #489be8;
     width: 1rem;
     height: 1rem;
 
     ${(props) =>
         !props.checked ? "border: 1px solid #7A848D" : "border: none"}
-`
-
+`;
 
 interface CheckboxProps {
     checked: boolean;
 }
 
-const Checkbox = ({checked}: CheckboxProps) => {
-
+const Checkbox = ({ checked }: CheckboxProps) => {
     return (
         <div
             aria-checked="false"
@@ -41,10 +39,10 @@ const Checkbox = ({checked}: CheckboxProps) => {
             }}
         >
             <IconContainer checked={checked}>
-                {checked && <FontAwesomeIcon icon={faCheckSquare}></FontAwesomeIcon>}
+                {checked && <FontAwesomeIcon icon={faCheckSquare} />}
             </IconContainer>
         </div>
     );
-}
+};
 
 export default Checkbox;

--- a/frontend/alert/components/managealert/Header.tsx
+++ b/frontend/alert/components/managealert/Header.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import { GridItem, Flex, RightItem } from "pcx-shared-components/src/common/layout";
+import {
+    GridItem,
+    Flex,
+    RightItem,
+} from "pcx-shared-components/src/common/layout";
 import { Img } from "../common/common";
 import { AlertAction } from "../../types";
 

--- a/frontend/alert/components/managealert/ManageAlertUI.tsx
+++ b/frontend/alert/components/managealert/ManageAlertUI.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import Header from "./Header";
 import { Flex } from "pcx-shared-components/src/common/layout";
+import Header from "./Header";
 import { AlertSearch } from "./AlertSearch";
 import { AlertItem } from "./AlertItem";
 import { maxWidth, PHONE } from "../../constants";

--- a/frontend/alert/components/managealert/index.tsx
+++ b/frontend/alert/components/managealert/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useMemo} from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import ReactGA from "react-ga";
 import useSWR from "swr";
 import { ManageAlert } from "./ManageAlertUI";

--- a/frontend/alert/next-env.d.ts
+++ b/frontend/alert/next-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types="next" />
-/// <reference types="next/types/global" />
+// / <reference types="next" />
+// / <reference types="next/types/global" />

--- a/frontend/alert/pages/index.tsx
+++ b/frontend/alert/pages/index.tsx
@@ -6,15 +6,19 @@ import * as Sentry from "@sentry/browser";
 import { useRouter } from "next/router";
 
 import AccountIndicator from "pcx-shared-components/src/accounts/AccountIndicator";
+import {
+    Center,
+    Container,
+    Flex,
+} from "pcx-shared-components/src/common/layout";
+import LoginModal from "pcx-shared-components/src/accounts/LoginModal";
 import ManageAlertWrapper from "../components/managealert";
 import { maxWidth, PHONE } from "../constants";
 import Footer from "../components/Footer";
 import AlertForm from "../components/AlertForm";
 import Timeline from "../components/Timeline";
 
-import { Center, Container, Flex } from "pcx-shared-components/src/common/layout";
 import MessageList from "../components/MessageList";
-import LoginModal from "pcx-shared-components/src/accounts/LoginModal";
 import { User } from "../types";
 
 const Tagline = styled.h3`
@@ -182,7 +186,12 @@ function App() {
     return (
         <>
             <Container>
-                {showLoginModal && <LoginModal pathname={window.location.pathname} siteName="Penn Course Alert"/>}
+                {showLoginModal && (
+                    <LoginModal
+                        pathname={window.location.pathname}
+                        siteName="Penn Course Alert"
+                    />
+                )}
                 {showRecruiting && (
                     <RecruitingBanner>
                         <p>
@@ -233,7 +242,7 @@ function App() {
                     <ManageAlertWrapper />
                 )}
 
-                <Timeline courseCode={timeline} setTimeline={setTimeline}/>
+                <Timeline courseCode={timeline} setTimeline={setTimeline} />
 
                 <Footer />
             </Container>

--- a/frontend/alert/util.ts
+++ b/frontend/alert/util.ts
@@ -1,18 +1,18 @@
 export const mapActivityToString = (activity) => {
     const activityStringMap = {
-        "CLN": "Clinics",
-        "DIS": "Dissertations",
-        "IND": "Independent Studies",
-        "LAB": "Labs",
-        "LEC": "Lectures",
-        "MST": "Masters Theses",
-        "REC": "Recitations",
-        "SEM": "Seminars",
-        "SRT": "Senior Theses",
-        "STU": "Studios",
-        "ONL": "Online",
+        CLN: "Clinics",
+        DIS: "Dissertations",
+        IND: "Independent Studies",
+        LAB: "Labs",
+        LEC: "Lectures",
+        MST: "Masters Theses",
+        REC: "Recitations",
+        SEM: "Seminars",
+        SRT: "Senior Theses",
+        STU: "Studios",
+        ONL: "Online",
         "***": "Uncategorized",
-    }
+    };
 
     return activityStringMap[activity];
-}
+};

--- a/frontend/alert/util.ts
+++ b/frontend/alert/util.ts
@@ -1,0 +1,18 @@
+export const mapActivityToString = (activity) => {
+    const activityStringMap = {
+        "CLN": "Clinics",
+        "DIS": "Dissertations",
+        "IND": "Independent Studies",
+        "LAB": "Labs",
+        "LEC": "Lectures",
+        "MST": "Masters Theses",
+        "REC": "Recitations",
+        "SEM": "Seminars",
+        "SRT": "Senior Theses",
+        "STU": "Studios",
+        "ONL": "Online",
+        "***": "Uncategorized",
+    }
+
+    return activityStringMap[activity];
+}


### PR DESCRIPTION
Add bulk registration to PCA. 

- Registering for one section works very similar to previously
- Enter "bulk mode" when user selected more than one section. 
- In "bulk mode", user cannot edit input field & suggestions would be locked. 
- Click "X" on the side of input field or select only one section to exit out of "bulk mode"
- Added notifications when all selected sections are successfully registered

- Dynamic select all buttons - supports all types of activities (LEC, REC, IND, SEM, etc)