### PR TITLE
Fix instructor duplication

### DIFF
--- a/backend/courses/util.py
+++ b/backend/courses/util.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+import uuid
 from decimal import Decimal
 
 from django.core.cache import cache
@@ -14,7 +15,6 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from options.models import Option, get_value
 from rest_framework.exceptions import APIException
-import uuid
 
 from courses.models import (
     Building,

--- a/backend/review/management/commands/mergeinstructors.py
+++ b/backend/review/management/commands/mergeinstructors.py
@@ -1,12 +1,11 @@
 import logging
+from collections import defaultdict
 from typing import Callable, Dict, List, Optional
 
 from django.core.management import BaseCommand
-from django.db.models.functions import Lower
 from tqdm import tqdm
 
-from courses.models import Instructor, Section
-from review.models import Review
+from courses.models import Instructor
 
 
 # Statistic keys
@@ -17,22 +16,26 @@ REVIEWS_MODIFIED = "reviews modified"
 INSTRUCTORS_UNMERGED = "instructors unmerged"
 
 
-def batch_duplicates(qs, get_prop) -> List[List[Instructor]]:
+def batch_duplicates(qs, get_prop=None, union_find=None) -> List[List[Instructor]]:
     """
-    Group queryset rows by a property defined in `get_prop()`, return a list-of-lists of groups
-    of size > 1.
-    :param qs: Queryset to use
-    :param get_prop: Function which takes a row and returns a property to group on.
-    If get_prop returns None, don't include the row in the groupings.
-    :return: List of lists of duplicate rows according to some property.
+    Group queryset rows by a property defined in `get_prop()` (or alternatively
+    specify groups with a union find dictionary). Return a list of groups of size > 1.
+    :param qs: Queryset of instructors to use
+    :param get_prop: Function mapping a row to a value to group on.
+        If `get_prop` returns `None`, don't include the row in the groupings.
+    :param union_find: Alternatively to specifying `get_prop`, you can specify
+        groups with a union find dictionary (mapping instructor id to
+        a root instructor id representing the group).
+        This kwarg accepts a function mapping `qs` to a union find dictionary.
+    :return: List of instructor groups of size > 1.
     """
-    rows_by_prop = dict()
-    for row in tqdm(qs):
-        prop = get_prop(row)
-        if prop is None:
-            continue
-        rows_by_prop.setdefault(prop, []).append(row)
-    return [rows for name, rows in rows_by_prop.items() if len(rows) > 1]
+    if union_find:
+        union_find = union_find(qs)
+        rows_by_prop = {union_find[row.id]: row for row in qs}
+    else:
+        assert get_prop
+        rows_by_prop = {get_prop(row): row for row in qs}
+    return [rows for prop, rows in rows_by_prop.items() if prop and len(rows) > 1]
 
 
 def resolve_duplicates(
@@ -55,7 +58,7 @@ def resolve_duplicates(
         # If no instance has a linked user, just pick one instructor.
         if len(potential_primary) == 0:
             stat(INSTRUCTORS_KEPT, 1)
-            primary_instructor = instructor_set[0]
+            primary_instructor = max(instructor_set, key=lambda i: i.updated_at)
         # If there's only one user with a linked user object, select that as the primary.
         # This should be the case that is hit most often.
         elif len(potential_primary) == 1:
@@ -66,7 +69,7 @@ def resolve_duplicates(
             # go ahead and choose one arbitrarily.
             if len(set([inst.user.pk for inst in potential_primary])) == 1 or force:
                 stat(INSTRUCTORS_KEPT, 1)
-                primary_instructor = potential_primary[0]
+                primary_instructor = max(potential_primary, key=lambda i: i.updated_at)
             # Otherwise, we don't have enough information to merge automatically. There are multiple
             # instructors marked as duplicates, but they link to different users and so could be
             # different people. Report the PKs of these instructors in the statistics, but don't
@@ -78,20 +81,16 @@ def resolve_duplicates(
                 continue
 
         # Filter for all instructors that aren't the primary.
-        duplicate_instructors = [
-            inst for inst in instructor_set if inst.pk != primary_instructor.pk
-        ]
+        duplicate_instructors = [inst for inst in instructor_set if inst != primary_instructor]
         # Transfer the sections and reviews of all non-primary instances to the primary instance.
         for duplicate_instructor in duplicate_instructors:
-            sections = Section.objects.filter(instructors=duplicate_instructor)
-            for section in sections:
+            for section in duplicate_instructor.sections.all():
                 stat(SECTIONS_MODIFIED, 1)
                 if not dry_run:
                     section.instructors.remove(duplicate_instructor)
                     section.instructors.add(primary_instructor)
 
-            reviews = Review.objects.filter(instructor=duplicate_instructor)
-            for review in reviews:
+            for review in duplicate_instructor.reviews.all():
                 stat(REVIEWS_MODIFIED, 1)
                 if not dry_run:
                     review.instructor = primary_instructor
@@ -108,16 +107,51 @@ which resolve a list of duplicate lists when called. The lambdas are to ensure
 lazy evaluation, since we won't necessarily be running all (or any) of the
 given strategies.
 """
+
+
+def first_last_name_sections_uf(instructors):
+    """
+    Groups instructors if they share a first name / last name, and have
+    taught the same section.
+    """
+
+    def get_first_last(name):
+        components = name.split(" ")
+        return (components[0], components[-1])
+
+    union_find = {inst.id: inst.id for inst in instructors}
+
+    for inst in tqdm(instructors):
+        inst_first_last = get_first_last(inst.name)
+        for section in inst.sections.all():
+            for other_inst in section.instructors.all():
+                if inst_first_last == get_first_last(other_inst.name):
+                    union_find[inst.id] = union_find[other_inst.id]
+
+    def get_root_id(inst_id):
+        while union_find[inst_id] != inst_id:
+            inst_id = union_find[inst_id]
+        return inst_id
+
+    for inst_id in union_find:
+        union_find[inst_id] = get_root_id(inst_id)
+
+    return union_find
+
+
 strategies: Dict[str, Callable[[], List[List[Instructor]]]] = {
     "case-insensitive": lambda: batch_duplicates(
-        Instructor.objects.all().annotate(name_lower=Lower("name")).order_by("-updated_at"),
-        lambda row: row.name_lower,
+        Instructor.objects.all().prefetch_related("sections", "reviews"),
+        lambda row: row.name.lower(),
     ),
     "pennid": lambda: batch_duplicates(
-        Instructor.objects.all().order_by("-updated_at").select_related("user"),
-        lambda row: row.user.pk if row.user is not None else None,
+        Instructor.objects.all().prefetch_related("sections", "reviews"),
+        lambda row: row.user_id,
     ),
-    # Middle Initial ([\w ']+)([a-zA-Z]+\.)([\w ']+)
+    "first-last-name-sections": lambda: batch_duplicates(
+        Instructor.objects.all().prefetch_related("sections", "reviews", "sections__instructors"),
+        union_find=lambda rows: first_last_name_sections_uf(rows),
+    ),
 }
 
 
@@ -127,7 +161,7 @@ class Command(BaseCommand):
 
     case-insensitive: Merge instructors with the same name but different cases [O'leary, O'Leary]
     pennid: Merge instructors with the same pennid
-    middle-initial: Merge instructors based on firstname and lastname, ignoring middle initials.
+    first-last-name-sections: Merge instructors based on firstname, lastname and shared sections.
     """
 
     def add_arguments(self, parser):

--- a/backend/review/management/commands/mergeinstructors.py
+++ b/backend/review/management/commands/mergeinstructors.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 from typing import Callable, Dict, List, Optional
 
 from django.core.management import BaseCommand

--- a/backend/review/management/commands/mergeinstructors.py
+++ b/backend/review/management/commands/mergeinstructors.py
@@ -214,7 +214,7 @@ class Command(BaseCommand):
 
         if len(manual_merge) > 0:
             print("***Merging records manually***")
-            run_merge(lambda: [list(Instructor.objects.filter(pk__in=manual_merge))], force=True)
+            run_merge(lambda: [set(Instructor.objects.filter(pk__in=manual_merge))], force=True)
         else:
             if selected_strategies is None:
                 selected_strategies = list(strategies.keys())

--- a/backend/review/urls.py
+++ b/backend/review/urls.py
@@ -41,5 +41,5 @@ urlpatterns = [
         cache_page(DAY_IN_SECONDS)(instructor_for_course_reviews),
         name="course-history",
     ),
-    path("autocomplete", cache_page(HOUR_IN_SECONDS)(autocomplete), name="review-autocomplete"),
+    path("autocomplete", cache_page(DAY_IN_SECONDS)(autocomplete), name="review-autocomplete"),
 ]

--- a/backend/tests/review/test_mergeinstructors.py
+++ b/backend/tests/review/test_mergeinstructors.py
@@ -74,9 +74,9 @@ class ResolveDuplicatesTestCase(TestCase):
     def test_basic_merge(self):
         resolve_duplicates([[self.inst_A, self.inst_a]], False, self.stat)
         self.assertEqual(2, Instructor.objects.count())
-        self.assertFalse(Instructor.objects.filter(name="a").exists())
-        self.assertEqual(2, Review.objects.filter(instructor=self.inst_A).count())
-        self.assertEqual(2, Section.objects.filter(instructors=self.inst_A).count())
+        self.assertFalse(Instructor.objects.filter(name="A").exists())
+        self.assertEqual(2, Review.objects.filter(instructor=self.inst_a).count())
+        self.assertEqual(2, Section.objects.filter(instructors=self.inst_a).count())
 
     def test_basic_merge_dryrun_doesnt_modify(self):
         resolve_duplicates([[self.inst_A, self.inst_a]], True, self.stat)
@@ -87,13 +87,13 @@ class ResolveDuplicatesTestCase(TestCase):
         self.assertEqual(1, Section.objects.filter(instructors=self.inst_a).count())
 
     def test_merge_with_user(self):
-        self.inst_a.user = self.user1
-        self.inst_a.save()
+        self.inst_A.user = self.user1
+        self.inst_A.save()
         resolve_duplicates([[self.inst_A, self.inst_a]], False, self.stat)
         self.assertEqual(2, Instructor.objects.count())
-        self.assertFalse(Instructor.objects.filter(name="A").exists())
-        self.assertEqual(2, Review.objects.filter(instructor=self.inst_a).count())
-        self.assertEqual(2, Section.objects.filter(instructors=self.inst_a).count())
+        self.assertFalse(Instructor.objects.filter(name="a").exists())
+        self.assertEqual(2, Review.objects.filter(instructor=self.inst_A).count())
+        self.assertEqual(2, Section.objects.filter(instructors=self.inst_A).count())
 
     def test_merge_with_both_having_same_user(self):
         self.inst_a.user = self.user1
@@ -102,9 +102,9 @@ class ResolveDuplicatesTestCase(TestCase):
         self.inst_A.save()
         resolve_duplicates([[self.inst_A, self.inst_a]], False, self.stat)
         self.assertEqual(2, Instructor.objects.count())
-        self.assertFalse(Instructor.objects.filter(name="a").exists())
-        self.assertEqual(2, Review.objects.filter(instructor=self.inst_A).count())
-        self.assertEqual(2, Section.objects.filter(instructors=self.inst_A).count())
+        self.assertFalse(Instructor.objects.filter(name="A").exists())
+        self.assertEqual(2, Review.objects.filter(instructor=self.inst_a).count())
+        self.assertEqual(2, Section.objects.filter(instructors=self.inst_a).count())
 
     def test_merge_aborts_with_different_users(self):
         self.inst_a.user = self.user1

--- a/frontend/review/package.json
+++ b/frontend/review/package.json
@@ -7,8 +7,10 @@
     "fuzzysort": "^1.1.4",
     "http-proxy-middleware": "^0.20.0",
     "js-cookie": "^2.2.1",
+    "lz-string": "^1.4.4",
     "react": "^16.12.0",
     "react-app-polyfill": "^1.0.5",
+    "react-app-rewired": "^2.2.1",
     "react-chartjs-2": "^2.8.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
@@ -17,7 +19,8 @@
     "react-string-replace": "^0.4.4",
     "react-table": "^6.11.5",
     "react-tooltip": "^4.2.17",
-    "universal-cookie": "^4.0.2"
+    "universal-cookie": "^4.0.2",
+    "workerize-loader": "^1.3.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/review/src/config-overrides.js
+++ b/frontend/review/src/config-overrides.js
@@ -1,0 +1,7 @@
+module.exports = function override(config, env) {
+  config.module.rules.push({
+    test: /\.worker\.js$/,
+    use: { loader: "worker-loader" }
+  });
+  return config;
+};

--- a/frontend/review/src/utils/api.js
+++ b/frontend/review/src/utils/api.js
@@ -1,3 +1,9 @@
+import autocompleteWorker from "workerize-loader!../workers/autocomplete.worker"; // eslint-disable-line import/no-webpack-loader-syntax
+
+const autocompleteWorkerInstance = autocompleteWorker();
+const compressAutocomplete = autocompleteWorkerInstance.compress;
+const decompressAutocomplete = autocompleteWorkerInstance.decompress;
+
 const API_DOMAIN = `${window.location.protocol}//${window.location.host}`;
 const PUBLIC_API_TOKEN = "public";
 const API_TOKEN = "platform";
@@ -18,30 +24,53 @@ export function getLogoutUrl() {
   )}`;
 }
 
+// Necessary for backwards compatibility (we used to just store uncompressed
+// JSON stringified autocomplete data)
+const isCompressedAutocomplete = data => {
+  return data.startsWith("compressed:");
+};
+
+// Cache the decompressed autocomplete dump as a global variable
+var uncompressedAutocompleteData = null;
+
 export function apiAutocomplete() {
+  // If we have decompressed autocomplete data since last page refresh, return previous data.
+  if (uncompressedAutocompleteData) {
+    return Promise.resolve(uncompressedAutocompleteData);
+  }
   // Cache the autocomplete JSON in local storage using the stale-while-revalidate
   // strategy.
   const key = "meta-pcr-autocomplete";
   const cached_autocomplete = localStorage.getItem(key);
   if (cached_autocomplete) {
     // If a cached version exists, replace it in the cache asynchronously and return the old cache.
-    apiFetch(`${API_DOMAIN}/api/review/autocomplete`).then(data => {
-      try {
-        localStorage.setItem(key, JSON.stringify(data));
-      } catch (e) {}
-    });
-    return new Promise((resolve, reject) =>
-      resolve(JSON.parse(cached_autocomplete))
-    );
+    apiFetch(`${API_DOMAIN}/api/review/autocomplete`)
+      .then(compressAutocomplete)
+      .then(compressed => {
+        try {
+          localStorage.setItem(key, compressed);
+        } catch (e) {
+          localStorage.removeItem(key);
+        }
+      });
+    return isCompressedAutocomplete(cached_autocomplete)
+      ? decompressAutocomplete(cached_autocomplete)
+      : Promise.resolve(cached_autocomplete);
   } else {
     // If no cached data exists, fetch, set the cache and return in the same promise.
     return new Promise((resolve, reject) => {
-      apiFetch(`${API_DOMAIN}/api/review/autocomplete`).then(data => {
-        try {
-          localStorage.setItem(key, JSON.stringify(data));
-        } catch (e) {}
-        resolve(data);
-      });
+      apiFetch(`${API_DOMAIN}/api/review/autocomplete`)
+        .then(data => {
+          resolve(data);
+          return compressAutocomplete(data);
+        })
+        .then(compressed => {
+          try {
+            localStorage.setItem(key, compressed);
+          } catch (e) {
+            localStorage.removeItem(key);
+          }
+        });
     });
   }
 }

--- a/frontend/review/src/workers/autocomplete.worker.js
+++ b/frontend/review/src/workers/autocomplete.worker.js
@@ -1,0 +1,7 @@
+import LZString from "lz-string";
+
+export const compress = data =>
+  "compressed:" + LZString.compress(JSON.stringify(data));
+
+export const decompress = data =>
+  JSON.parse(LZString.decompress(data.substring("compressed:".length)));

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10005,6 +10005,11 @@ lru-cache@5.1.1, lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -12775,6 +12780,13 @@ react-app-rewired@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.6.tgz#33ee3076a7f34d6a7c94e649cac67e7c8c580de8"
   integrity sha512-06flj0kK5tf/RN4naRv/sn6j3sQd7rsURoRLKLpffXDzJeNiAaTNic+0I8Basojy5WDwREkTqrMLewSAjcb13w==
+  dependencies:
+    semver "^5.6.0"
+
+react-app-rewired@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.2.1.tgz#84901ee1e3f26add0377ebec0b41bcdfce9fc211"
+  integrity sha512-uFQWTErXeLDrMzOJHKp0h8P1z0LV9HzPGsJ6adOtGlA/B9WfT6Shh4j2tLTTGlXOfiVx6w6iWpp7SOC5pvk+gA==
   dependencies:
     semver "^5.6.0"
 
@@ -15865,6 +15877,13 @@ worker-rpc@^0.1.0:
   integrity sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==
   dependencies:
     microevent.ts "~0.1.1"
+
+workerize-loader@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/workerize-loader/-/workerize-loader-1.3.0.tgz#4995cf2ff2b45dd6dc60e4411e63f5ae2c704d36"
+  integrity sha512-utWDc8K6embcICmRBUUkzanPgKBb8yM1OHfh6siZfiMsswE8wLCa9CWS+L7AARz0+Th4KH4ZySrqer/OJ9WuWw==
+  dependencies:
+    loader-utils "^2.0.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
- Create a `User` object for new instructors using their PennID in the registrarimport `set_instructors` function.
- Improve the `mergeinstructors` script, handle middle initial case, look at shared sections taught
- Add more testing for `mergeinstructors`
- Fix the infinite caching issue with PCR autocomplete, use LZ string compression to store autocomplete dump in local storage (below storage limit), use web workers to compress / decompress autocomplete dump without hanging the UI.