### PR TITLE
Change PCA Alert Text to Path@Penn

### DIFF
--- a/backend/alert/templates/alert/text_alert.txt
+++ b/backend/alert/templates/alert/text_alert.txt
@@ -1,3 +1,3 @@
-{{course}} is open! Register on PennInTouch: http://bit.ly/pitouch.
+{{course}} is open! Register on Path@Penn: http://bit.ly/pathpenn.
 {% if auto_resubscribe %}To cancel alerts, visit{% else %}Resubscribe at{% endif %} http://u.pennlabs.org/pca
 - Thanks for using Penn Course Alert!


### PR DESCRIPTION
Change text from PennInTouch to Path@Penn. Used https://twiliodeved.github.io/message-segment-calculator/ to make sure text is 1 segment. 

Also should we consider deleting "- Thanks for using Penn Course Alert!" since sometimes the message can be 2 segments because of new 4-digit course code. 