### PR TITLE
[Deployment] Fix Backend Deployment Bug

### DIFF
--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -16,7 +16,7 @@ export class MyChart extends PennLabsChart {
     new DjangoApplication(this, 'celery', {
       deployment: {
         image: backendImage,
-        secret: secret,
+        secret,
         cmd: ['celery', 'worker', '-A', 'PennCourses', '-Q', 'alerts,celery', '-linfo'],
       },
       djangoSettingsModule: 'PennCourses.settings.production',
@@ -25,10 +25,8 @@ export class MyChart extends PennLabsChart {
     new DjangoApplication(this, 'backend', {
       deployment: {
         image: backendImage,
-        secret: secret,
-        cmd: ['celery', 'worker', '-A', 'PennCourses', '-Q', 'alerts,celery', '-linfo'],
+        secret,
         replicas: 3,
-        env: [{ name: 'PORT', value: '80' }],
       },
       djangoSettingsModule: 'PennCourses.settings.production',
       ingressProps: {
@@ -70,14 +68,14 @@ export class MyChart extends PennLabsChart {
     new CronJob(this, 'load-courses', {
       schedule: cronTime.everyDayAt(3),
       image: backendImage,
-      secret: secret,
+      secret,
       cmd: ['python', 'manage.py', 'registrarimport'],
     });
 
     new CronJob(this, 'report-stats', {
       schedule: cronTime.everyDayAt(20),
       image: backendImage,
-      secret: secret,
+      secret,
       cmd: ['python', 'manage.py', 'alertstats', '1', '--slack'],
     });
 


### PR DESCRIPTION
This PR fixes the courses backend bug from the previous transition to Kittyhawk, as well as making some nit improvements on the kittyhawk deployment code. 

### Cause for problem
After switching from Icarus to Kittyhawk in PR #358, our courses products began experiencing problems at any of the subroutes (e.g. `/admin` or `/accounts`) with a `Bad Gateway` error. The products are still viewable and frontend available, but anything that required logging in or searching for course review were down.

Because all of the products were still accessible yet unfunctional, this must be caused by something shared by all courses product, which narrows the problem to the courses backend. After reinstalling the products using icarus (helm) last night and taking a closer comparison at the yaml today, I found out that the results were due to an extra line [here](https://github.com/pennlabs/penn-courses/commit/3560bd3c83e87cba363778234613adbab33192b9#diff-df2a98b7bc1962cde3af1fd1d53a173d4474ac9a9468fe3464f75c863b08cb6bL29). 

### Prevention in the future
This is a DevOops. I was trying to transition a lot of products over and should have not only taken a closer look at whether the yaml itself made sense, but also at the original configurations. Earlier, I also accidentally misspelled some of our products domains (e.g. penncourse.org vs .com) :'D

In the future, it would be beneficial to keep an improved checklist for deployment transitions, as well as have another person review non-time-sensitive migration PRs like these in order to catch any mistakes. 

Also, with [argo-cd](https://github.com/pennlabs/infrastructure/pull/146), we can compare changes in deployment config more easily. 