### PR TITLE
Accept Schedules from Penn Mobile

### DIFF
--- a/backend/courses/filters.py
+++ b/backend/courses/filters.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+decimalfrom decimal import Decimal
 
 from django.core.exceptions import BadRequest
 from django.db.models import Count, Exists, OuterRef, Q

--- a/backend/courses/views.py
+++ b/backend/courses/views.py
@@ -220,7 +220,6 @@ class CourseListSearch(CourseList):
     filter_backends = [TypedCourseSearchBackend, CourseSearchFilterBackend]
     search_fields = ("full_code", "title", "sections__instructors__name")
 
-
 class CourseDetail(generics.RetrieveAPIView, BaseCourseMixin):
     """
     Retrieve a detailed look at a specific course. Includes all details necessary to display course

--- a/backend/plan/models.py
+++ b/backend/plan/models.py
@@ -43,6 +43,16 @@ class Schedule(models.Model):
         """
         ),
     )
+    is_adv_reg = models.BooleanField(
+        default=False,
+        db_index=True,
+        help_text=dedent(
+            """
+            Whether this schedule is from advanced registration. Schedules of this type are hidden
+            on the front end.
+        """
+        ),
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/plan/urls.py
+++ b/backend/plan/urls.py
@@ -2,15 +2,17 @@ from django.urls import include, path
 from django.views.generic import TemplateView
 from rest_framework import routers
 
-from plan.views import ScheduleViewSet, recommend_courses_view
+from plan.views import ScheduleViewSet, recommend_courses_view, penn_mobile_schedule_view
 
 
 router = routers.DefaultRouter()
+router.register(r"schedules", ScheduleViewSet, basename="schedules")
 router.register(r"schedules", ScheduleViewSet, basename="schedules")
 
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="plan/build/index.html")),
     path("recommendations/", recommend_courses_view, name="recommend-courses"),
+    path("penn-mobile-schedule/", penn_mobile_schedule_view, name="penn-mobile-schedule"),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
This pull request creates a token-authenticated endpoint Penn Mobile can hit to create a special type of schedule.

TODO:
- [ ] Figure out how to allow token authentication
- [ ] Figure out how these new schedules should be named
- [ ] Rename the endpoint to something less confusing
- [ ] Test
- [ ] Add docs