### PR TITLE
Add temporary warning banner regarding failing text alerts on AT&T

### DIFF
--- a/frontend/alert/pages/index.tsx
+++ b/frontend/alert/pages/index.tsx
@@ -127,6 +127,10 @@ const RecruitingBanner = styled.div`
     }
 `;
 
+const WarningBanner = styled(RecruitingBanner)`
+    background-color: #d2d7df;
+`;
+
 function App() {
     const router = useRouter();
     const [user, setUser] = useState<User | null>(null);
@@ -214,6 +218,18 @@ function App() {
                         </p>
                     </RecruitingBanner>
                 )}
+                <WarningBanner>
+                    <p>
+                        <span role="img" aria-label="warning">
+                            ⚠️
+                        </span>{" "}
+                        If your carrier is AT&T, you may not recieve text
+                        alerts.{" "}
+                        <span role="img" aria-label="warning">
+                            ⚠️
+                        </span>{" "}
+                    </p>
+                </WarningBanner>
                 <Nav
                     login={updateUser}
                     logout={logout}


### PR DESCRIPTION

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/57609353/204444995-b9fd105a-b0ba-4221-b8e4-2fb976b75966.png">


TO DO
- [ ] fix potential scrolling issue (banner forces PCA page to overflow, resulting in a scroll bar)
- [ ] remove this