### PR TITLE
PCR: limit fields aggregated on an instructor's courses

### DIFF
--- a/backend/review/annotations.py
+++ b/backend/review/annotations.py
@@ -258,7 +258,7 @@ def annotate_with_matching_reviews(
     )
 
 
-def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_metrics=True):
+def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_metrics=True, fields=None):
     """
     Annotate queryset with both all reviews and recent reviews.
     :param qs: Queryset to annotate.
@@ -272,6 +272,7 @@ def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_met
     :param: extra_metrics: option to include extra metrics in PCR aggregations; final enrollment,
         percent of add/drop period open, average number of openings during add/drop,
         and percentage of sections filled in advance registration
+    :param: fields: option to specify the fields averaged by the query
     """
     qs = annotate_with_matching_reviews(
         qs,
@@ -280,6 +281,7 @@ def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_met
         most_recent=False,
         prefix="average_",
         extra_metrics=extra_metrics,
+        fields=fields
     )
     qs = annotate_with_matching_reviews(
         qs,
@@ -288,5 +290,6 @@ def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_met
         most_recent=True,
         prefix="recent_",
         extra_metrics=extra_metrics,
+        fields=fields
     )
     return qs

--- a/backend/review/annotations.py
+++ b/backend/review/annotations.py
@@ -258,7 +258,9 @@ def annotate_with_matching_reviews(
     )
 
 
-def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_metrics=True, fields=None):
+def annotate_average_and_recent(
+    qs, match_review_on, match_section_on, extra_metrics=True, fields=None
+):
     """
     Annotate queryset with both all reviews and recent reviews.
     :param qs: Queryset to annotate.
@@ -281,7 +283,7 @@ def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_met
         most_recent=False,
         prefix="average_",
         extra_metrics=extra_metrics,
-        fields=fields
+        fields=fields,
     )
     qs = annotate_with_matching_reviews(
         qs,
@@ -290,6 +292,6 @@ def annotate_average_and_recent(qs, match_review_on, match_section_on, extra_met
         most_recent=True,
         prefix="recent_",
         extra_metrics=extra_metrics,
-        fields=fields
+        fields=fields,
     )
     return qs

--- a/backend/review/util.py
+++ b/backend/review/util.py
@@ -476,12 +476,16 @@ def avg_and_recent_demand_plots(section_map, status_updates_map, bin_size=0.01):
                         if param_shape is None or param_loc is None or param_scale is None:
                             rel_demand = csrdv_frac_zero
                         else:
-                            rel_demand = csrdv_frac_zero + stats.lognorm.cdf(
-                                raw_demand,
-                                param_shape,
-                                param_loc,
-                                param_scale,
-                            ) * (1 - csrdv_frac_zero)
+                            rel_demand = (
+                                csrdv_frac_zero
+                                + stats.lognorm.cdf(
+                                    raw_demand,
+                                    param_shape,
+                                    param_loc,
+                                    param_scale,
+                                )
+                                * (1 - csrdv_frac_zero)
+                            )
                 if change["percent_through"] > bin_start_pct + bin_size:
                     if num_in_bin > 0:
                         bin_avg = total_value_in_bin / num_in_bin

--- a/backend/review/util.py
+++ b/backend/review/util.py
@@ -476,16 +476,12 @@ def avg_and_recent_demand_plots(section_map, status_updates_map, bin_size=0.01):
                         if param_shape is None or param_loc is None or param_scale is None:
                             rel_demand = csrdv_frac_zero
                         else:
-                            rel_demand = (
-                                csrdv_frac_zero
-                                + stats.lognorm.cdf(
-                                    raw_demand,
-                                    param_shape,
-                                    param_loc,
-                                    param_scale,
-                                )
-                                * (1 - csrdv_frac_zero)
-                            )
+                            rel_demand = csrdv_frac_zero + stats.lognorm.cdf(
+                                raw_demand,
+                                param_shape,
+                                param_loc,
+                                param_scale,
+                            ) * (1 - csrdv_frac_zero)
                 if change["percent_through"] > bin_start_pct + bin_size:
                     if num_in_bin > 0:
                         bin_avg = total_value_in_bin / num_in_bin

--- a/backend/review/views.py
+++ b/backend/review/views.py
@@ -364,6 +364,7 @@ def check_instructor_id(instructor_id):
     ):
         raise Http404("Instructor with given instructor_id not found.")
 
+INSTRUCTOR_COURSE_REVIEW_FIELDS = ["instructor_quality", "course_quality", "work_required", "difficulty"]
 
 @api_view(["GET"])
 @schema(
@@ -419,6 +420,7 @@ def instructor_reviews(request, instructor_id):
         )
         & section_filters_pcr,
         extra_metrics=True,
+        fields=INSTRUCTOR_COURSE_REVIEW_FIELDS
     ).annotate(
         most_recent_full_code=F("topic__most_recent__full_code"),
     )

--- a/backend/review/views.py
+++ b/backend/review/views.py
@@ -364,7 +364,14 @@ def check_instructor_id(instructor_id):
     ):
         raise Http404("Instructor with given instructor_id not found.")
 
-INSTRUCTOR_COURSE_REVIEW_FIELDS = ["instructor_quality", "course_quality", "work_required", "difficulty"]
+
+INSTRUCTOR_COURSE_REVIEW_FIELDS = [
+    "instructor_quality",
+    "course_quality",
+    "work_required",
+    "difficulty",
+]
+
 
 @api_view(["GET"])
 @schema(
@@ -420,7 +427,7 @@ def instructor_reviews(request, instructor_id):
         )
         & section_filters_pcr,
         extra_metrics=True,
-        fields=INSTRUCTOR_COURSE_REVIEW_FIELDS
+        fields=INSTRUCTOR_COURSE_REVIEW_FIELDS,
     ).annotate(
         most_recent_full_code=F("topic__most_recent__full_code"),
     )


### PR DESCRIPTION
This pull request limits the fields aggregated for each course an instructor teaches to those displayed by the frontend, namely:
1. `course_quality`
2. `instructor_quality`
3. `difficulty`
4. `work_required`
It limits the fields for both `average` and `recent` aggregations.