### PR TITLE
Correctly apply phone number validation on PCA backend

### DIFF
--- a/backend/courses/models.py
+++ b/backend/courses/models.py
@@ -1369,7 +1369,6 @@ class UserProfile(models.Model):
             return
         try:
             parsed_number = phonenumbers.parse(value, "US")
-            print(parsed_number)
             if not phonenumbers.is_valid_number(parsed_number):
                 raise ValueError(f"Invalid phone number '{value}'.")
         except (phonenumbers.phonenumberutil.NumberParseException, ValueError) as e:

--- a/backend/courses/models.py
+++ b/backend/courses/models.py
@@ -1359,14 +1359,21 @@ class UserProfile(models.Model):
         """
         Validator to check that a phone number is in the proper form. The number must be in a
         form which is parseable by the
-        [phonenumbers library](https://pypi.org/project/phonenumbers/).
+        [phonenumbers library](https://pypi.org/project/phonenumbers/) and also valid.
+
+        Note: validators are NOT called automatically on model object save. They are called
+        on `object.full_clean()`, and also on serializer validation (returning a 400 if violated).
+        https://docs.djangoproject.com/en/4.2/ref/validators/
         """
-        if value.strip() == "":
+        if not value or not value.strip():
             return
         try:
-            phonenumbers.parse(value, "US")
-        except phonenumbers.phonenumberutil.NumberParseException:
-            raise ValidationError("Enter a valid phone number.")
+            parsed_number = phonenumbers.parse(value, "US")
+            print(parsed_number)
+            if not phonenumbers.is_valid_number(parsed_number):
+                raise ValueError(f"Invalid phone number '{value}'.")
+        except (phonenumbers.phonenumberutil.NumberParseException, ValueError) as e:
+            raise ValidationError(str(e))
 
     phone = models.CharField(
         blank=True,
@@ -1396,16 +1403,14 @@ class UserProfile(models.Model):
         does not throw an error.
         It then calls the normal save method.
         """
-        if self.phone is not None and self.phone.strip() == "":
+        if not self.phone or not self.phone.strip():
             self.phone = None
-        if self.phone is not None:
-            try:
-                phone_number = phonenumbers.parse(self.phone, "US")
-                self.phone = phonenumbers.format_number(
-                    phone_number, phonenumbers.PhoneNumberFormat.E164
-                )
-            except phonenumbers.phonenumberutil.NumberParseException:
-                raise ValidationError("Invalid phone number (this should have been caught already)")
+        if self.phone:
+            # self.phone validated by `validate_phone`
+            phone_number = phonenumbers.parse(self.phone, "US")
+            self.phone = phonenumbers.format_number(
+                phone_number, phonenumbers.PhoneNumberFormat.E164
+            )
         super().save(*args, **kwargs)
 
 

--- a/backend/courses/models.py
+++ b/backend/courses/models.py
@@ -1405,7 +1405,7 @@ class UserProfile(models.Model):
         if not self.phone or not self.phone.strip():
             self.phone = None
         if self.phone:
-            # self.phone validated by `validate_phone`
+            # self.phone should be validated by `validate_phone`
             phone_number = phonenumbers.parse(self.phone, "US")
             self.phone = phonenumbers.format_number(
                 phone_number, phonenumbers.PhoneNumberFormat.E164

--- a/backend/tests/alert/test_alert.py
+++ b/backend/tests/alert/test_alert.py
@@ -1031,7 +1031,7 @@ class AlertRegistrationTestCase(TestCase):
         self.user = User.objects.create_user(username="jacob", password="top_secret")
         self.user.save()
         self.user.profile.email = "j@gmail.com"
-        self.user.profile.phone = "+11234567890"
+        self.user.profile.phone = "+119178286431"
         self.user.profile.save()
         self.user = User.objects.get(username="jacob")
         self.client = APIClient()
@@ -1124,7 +1124,7 @@ class AlertRegistrationTestCase(TestCase):
         contact_infos = (
             # If we enabled push notifications by default in these tests, push_username would be
             # set to "jacob", since that is the username of the default user for these tests.
-            [{"number": "+11234567890", "email": "j@gmail.com", "push_username": None}]
+            [{"number": "+119178286431", "email": "j@gmail.com", "push_username": None}]
             if contact_infos is None
             else contact_infos
         )
@@ -1673,7 +1673,7 @@ class AlertRegistrationTestCase(TestCase):
                     "email": new_user.profile.email,
                     "push_username": new_user.username,
                 },
-                {"number": "+11234567890", "email": "j@gmail.com", "push_username": None},
+                {"number": "+119178286431", "email": "j@gmail.com", "push_username": None},
             ],
             should_send=True,
             close_notification=False,
@@ -1743,7 +1743,7 @@ class AlertRegistrationTestCase(TestCase):
             self.cis1200,
             5,
             [
-                {"number": "+11234567890", "email": "j@gmail.com"},
+                {"number": "+119178286431", "email": "j@gmail.com"},
                 {"number": "+12234567890", "email": "newj@gmail.com"},
             ],
         )
@@ -2435,7 +2435,7 @@ class AlertRegistrationTestCase(TestCase):
         possible cases; with push notifications enabled (push_notif parameter set to True),
         or disabled (push_notif set to False).
         """
-        contact_infos = [{"number": "+11234567890", "email": "j@gmail.com", "push_username": None}]
+        contact_infos = [{"number": "+119178286431", "email": "j@gmail.com", "push_username": None}]
         if push_notif:
             response = self.client.put(
                 reverse("user-view"),
@@ -2574,7 +2574,7 @@ class AlertRegistrationTestCase(TestCase):
         Ensure that cancelling or deleting a registration also cancels a pending close notification
         """
         contact_infos = [
-            {"number": "+11234567890", "email": "j@gmail.com", "push_username": self.user.username}
+            {"number": "+119178286431", "email": "j@gmail.com", "push_username": self.user.username}
         ]
         first_id = self.registration_cis1200.id
 

--- a/backend/tests/alert/test_alert.py
+++ b/backend/tests/alert/test_alert.py
@@ -1031,7 +1031,7 @@ class AlertRegistrationTestCase(TestCase):
         self.user = User.objects.create_user(username="jacob", password="top_secret")
         self.user.save()
         self.user.profile.email = "j@gmail.com"
-        self.user.profile.phone = "+119178286431"
+        self.user.profile.phone = "+19178286431"
         self.user.profile.save()
         self.user = User.objects.get(username="jacob")
         self.client = APIClient()
@@ -1124,7 +1124,7 @@ class AlertRegistrationTestCase(TestCase):
         contact_infos = (
             # If we enabled push notifications by default in these tests, push_username would be
             # set to "jacob", since that is the username of the default user for these tests.
-            [{"number": "+119178286431", "email": "j@gmail.com", "push_username": None}]
+            [{"number": "+19178286431", "email": "j@gmail.com", "push_username": None}]
             if contact_infos is None
             else contact_infos
         )
@@ -1673,7 +1673,7 @@ class AlertRegistrationTestCase(TestCase):
                     "email": new_user.profile.email,
                     "push_username": new_user.username,
                 },
-                {"number": "+119178286431", "email": "j@gmail.com", "push_username": None},
+                {"number": "+19178286431", "email": "j@gmail.com", "push_username": None},
             ],
             should_send=True,
             close_notification=False,
@@ -1743,7 +1743,7 @@ class AlertRegistrationTestCase(TestCase):
             self.cis1200,
             5,
             [
-                {"number": "+119178286431", "email": "j@gmail.com"},
+                {"number": "+19178286431", "email": "j@gmail.com"},
                 {"number": "+12234567890", "email": "newj@gmail.com"},
             ],
         )
@@ -2435,7 +2435,7 @@ class AlertRegistrationTestCase(TestCase):
         possible cases; with push notifications enabled (push_notif parameter set to True),
         or disabled (push_notif set to False).
         """
-        contact_infos = [{"number": "+119178286431", "email": "j@gmail.com", "push_username": None}]
+        contact_infos = [{"number": "+19178286431", "email": "j@gmail.com", "push_username": None}]
         if push_notif:
             response = self.client.put(
                 reverse("user-view"),
@@ -2574,7 +2574,7 @@ class AlertRegistrationTestCase(TestCase):
         Ensure that cancelling or deleting a registration also cancels a pending close notification
         """
         contact_infos = [
-            {"number": "+119178286431", "email": "j@gmail.com", "push_username": self.user.username}
+            {"number": "+19178286431", "email": "j@gmail.com", "push_username": self.user.username}
         ]
         first_id = self.registration_cis1200.id
 

--- a/backend/tests/courses/test_api.py
+++ b/backend/tests/courses/test_api.py
@@ -716,14 +716,14 @@ class UserTestCase(TestCase):
         self.assertEqual(response.data["first_name"], "new_name")
         response = self.client.patch(
             "/accounts/me/",
-            json.dumps({"profile": {"phone": "3131234567"}}),
+            json.dumps({"profile": {"phone": "19178286431"}}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["first_name"], "new_name")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
 
     def test_settings_before_create(self):
         response = self.client.get(reverse("user-view"))
@@ -742,7 +742,7 @@ class UserTestCase(TestCase):
                 {
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": True,
                     }
                 }
@@ -751,7 +751,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -759,7 +759,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -774,7 +774,7 @@ class UserTestCase(TestCase):
                     "last_name": "",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": False,
                     },
                 }
@@ -783,7 +783,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "newname")
@@ -791,7 +791,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "newname")
@@ -806,7 +806,7 @@ class UserTestCase(TestCase):
                     "last_name": "newname",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": False,
                     },
                 }
@@ -815,7 +815,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -823,7 +823,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -839,7 +839,7 @@ class UserTestCase(TestCase):
                     "last_name": "",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": False,
                     },
                 }
@@ -848,7 +848,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -856,7 +856,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -872,7 +872,7 @@ class UserTestCase(TestCase):
                     "middle_name": "m",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": True,
                         "favorite_color": "blue",
                     },
@@ -882,7 +882,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertFalse("favorite_color" in response.data["profile"])
         self.assertEqual(response.data["username"], "jacob")
@@ -892,7 +892,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertFalse("favorite_color" in response.data["profile"])
         self.assertEqual(response.data["username"], "jacob")
@@ -909,7 +909,7 @@ class UserTestCase(TestCase):
                     "last_name": "lname",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": False,
                     },
                 }
@@ -923,7 +923,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example2@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "fname")
@@ -931,7 +931,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example2@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "fname")
@@ -946,7 +946,7 @@ class UserTestCase(TestCase):
                     "last_name": "lname",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "9178286431",
                         "push_notifications": True,
                     },
                 }
@@ -955,11 +955,11 @@ class UserTestCase(TestCase):
         )
         response = self.client.put(
             reverse("user-view"),
-            json.dumps({"profile": {"phone": "2121234567"}}),
+            json.dumps({"profile": {"phone": "2128289349"}}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["profile"]["phone"], "+12121234567")
+        self.assertEqual(response.data["profile"]["phone"], "+12128289349")
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
@@ -967,7 +967,7 @@ class UserTestCase(TestCase):
         self.assertEqual(response.data["last_name"], "lname")
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.data["profile"]["phone"], "+12121234567")
+        self.assertEqual(response.data["profile"]["phone"], "+12128289349")
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
@@ -987,7 +987,7 @@ class UserTestCase(TestCase):
                     "last_name": "lname",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": False,
                     },
                 }
@@ -1001,7 +1001,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "fname")
@@ -1009,7 +1009,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "fname")
@@ -1046,7 +1046,7 @@ class UserTestCase(TestCase):
                 {
                     "profile": {
                         "email": "example@",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": True,
                     }
                 }
@@ -1067,13 +1067,13 @@ class UserTestCase(TestCase):
         response = self.client.put(
             reverse("user-view"),
             json.dumps(
-                {"profile": {"email": None, "phone": "3131234567", "push_notifications": True}}
+                {"profile": {"email": None, "phone": "19178286431", "push_notifications": True}}
             ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], None)
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -1081,7 +1081,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], None)
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -1149,7 +1149,7 @@ class UserTestCase(TestCase):
                     "last_name": "",
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": "Rand",
                     },
                 }
@@ -1176,7 +1176,7 @@ class UserTestCase(TestCase):
                 {
                     "profile": {
                         "email": "example@email.com",
-                        "phone": "3131234567",
+                        "phone": "19178286431",
                         "push_notifications": "True",
                     }
                 }
@@ -1185,7 +1185,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -1193,7 +1193,7 @@ class UserTestCase(TestCase):
         response = self.client.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+13131234567")
+        self.assertEqual(response.data["profile"]["phone"], "+19178286431")
         self.assertTrue(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "jacob")
         self.assertEqual(response.data["first_name"], "")
@@ -1204,7 +1204,7 @@ class UserTestCase(TestCase):
                 {
                     "profile": {
                         "email": "example2@email.com",
-                        "phone": "2121234567",
+                        "phone": "2128289349",
                         "push_notifications": "False",
                     }
                 }
@@ -1213,7 +1213,7 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["profile"]["email"], "example2@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+12121234567")
+        self.assertEqual(response.data["profile"]["phone"], "+12128289349")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "murey")
         self.assertEqual(response.data["first_name"], "")
@@ -1221,7 +1221,7 @@ class UserTestCase(TestCase):
         response = client2.get(reverse("user-view"))
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.data["profile"]["email"], "example2@email.com")
-        self.assertEqual(response.data["profile"]["phone"], "+12121234567")
+        self.assertEqual(response.data["profile"]["phone"], "+12128289349")
         self.assertFalse(response.data["profile"]["push_notifications"])
         self.assertEqual(response.data["username"], "murey")
         self.assertEqual(response.data["first_name"], "")
@@ -1235,7 +1235,7 @@ class UserTestCase(TestCase):
                 {
                     "profile": {
                         "email": "example2@email.com",
-                        "phone": "2121234567",
+                        "phone": "2128289349",
                         "push_notifications": "True",
                     }
                 }


### PR DESCRIPTION
The PCA backend didn't used to actually validate phone numbers, as `phonenumbers.parse` doesn't validate. Changed the `UserProfile` validator to properly validate on serializer create (and `object.full_clean()` - NOT `object.save()` btw) and added some tests.