### PR TITLE
Bump node to 18

### DIFF
--- a/.github/workflows/shared-build-deploy.yaml
+++ b/.github/workflows/shared-build-deploy.yaml
@@ -55,6 +55,7 @@ jobs:
         product: [review, plan, alert]
     with:
       path: frontend/${{ matrix.product }}
+      nodeVersion: 18.19.0
 
   publish-frontend:
     uses: pennlabs/shared-actions/.github/workflows/docker-publish.yaml@v0.1

--- a/frontend/alert/Dockerfile
+++ b/frontend/alert/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-buster
+FROM node:18-bookworm
 
 LABEL maintainer="Penn Labs"
 

--- a/frontend/alert/package.json
+++ b/frontend/alert/package.json
@@ -33,9 +33,9 @@
     "typescript": "^3.9.5"
   },
   "scripts": {
-    "dev": "node server.js",
-    "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider node server.js",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider next build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production node server.js",
     "test": "echo no tests yet",
     "codecov": "echo no codecov",
     "lint": "eslint .",

--- a/frontend/plan/Dockerfile
+++ b/frontend/plan/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-buster
+FROM node:18-bookworm
 
 LABEL maintainer="Penn Labs"
 

--- a/frontend/plan/package.json
+++ b/frontend/plan/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "export NODE_OPTIONS=--openssl-legacy-provider && node server.js",
-    "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider next build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production node server.js",
     "test": "echo no tests yet",
     "codecov": "echo no codecov",
     "lint": "eslint . && tsc --noemit",

--- a/frontend/review/Dockerfile
+++ b/frontend/review/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-buster as build-deps
+FROM node:18-bookworm as build-deps
 
 WORKDIR /app/
 

--- a/frontend/review/package.json
+++ b/frontend/review/package.json
@@ -23,9 +23,9 @@
     "workerize-loader": "^1.3.0"
   },
   "scripts": {
-    "dev": "react-scripts start",
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "exit 0",
     "eject": "react-scripts eject",
     "lint": "prettier --check \"src/**/*.js\" && eslint \"./src/**/*.js\"",


### PR DESCRIPTION
Bumps node to 18 (previously used 10 for deployment, <=16 in development)

Note: this PR uses node's --openssl-legacy-provider option, which is the same behavior as in Node <= 16. This is insecure, though, so we should fix this in a separate PR.
