### PR TITLE
rollback: use kittyhawk 1.1.11 -> 1.1.9 (downgrade to 1.1.9)

### DIFF
--- a/k8s/package.json
+++ b/k8s/package.json
@@ -15,7 +15,7 @@
     "upgrade:next": "npm i cdk8s@next cdk8s-cli@next"
   },
   "dependencies": {
-    "@pennlabs/kittyhawk": "^1.1.11",
+    "@pennlabs/kittyhawk": "^1.1.9",
     "cdk8s": "^2.2.63",
     "constructs": "^10.0.119"
   },

--- a/k8s/yarn.lock
+++ b/k8s/yarn.lock
@@ -645,7 +645,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pennlabs/kittyhawk@^1.1.11":
+"@pennlabs/kittyhawk@^1.1.9":
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/@pennlabs/kittyhawk/-/kittyhawk-1.1.11.tgz#f0f8b96e45bdc3d4262067cf99b12d8620e3ca2d"
   integrity sha512-o/qQRXwdreaZuiq7Hf0tSjDBX5bzGOFCl447rK+6Nb8Z3IJmvTarc3UsSMs7Z9ndt/1CPoYmkaQS9KAAGIe0cw==


### PR DESCRIPTION
Redis persistence is causing networking issues between backend and redis, we will roll back to 1.1.9 (doesn't include persistence, previously working build) until we figure out why courses backend cannot talk to redis.

> For future reference, other products(ohq, clubs) are not experiencing this issue despite using kittyhawk@1.1.11