### PR TITLE
Removing Redis Stack and Reverting to Base Image

### DIFF
--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -19,10 +19,6 @@ export class MyChart extends PennLabsChart {
     }
 
     new RedisApplication(this, 'redis', {
-      deployment: { 
-	    image: 'redis/redis-stack-server',
-        tag: '6.2.6-v6'
-      },
       persistData: true,
     });
 


### PR DESCRIPTION
Temporarily reverting to base redis since Redis stack was used for PCS, which will be held off until our Fly Migration is complete. This will avoid the issues we've been having with protected mode in `penn-courses-redis`.