### PR TITLE
Update Review Data Parsing Scripts

### DIFF
--- a/backend/review/import_utils/import_to_db.py
+++ b/backend/review/import_utils/import_to_db.py
@@ -80,7 +80,12 @@ def import_review(section, instructor, enrollment, responses, form_type, bits, s
     )
     if not created:
         stat("duplicate_review")
-    review_bits = [ReviewBit(review=review, field=k, average=v) for k, v in bits.items()]
+    review_bits = []
+    for key, value in bits.items():
+        if value is None or value == "null":
+            stat(f"null value for {key}")
+            continue
+        review_bits.append(ReviewBit(review=review, field=key, average=value))
 
     # This saves us a bunch of database calls per row, since reviews have > 10 bits.
     ReviewBit.objects.bulk_create(review_bits, ignore_conflicts=True)
@@ -195,7 +200,7 @@ def import_ratings_row(row, stat):
     }
 
     for key, val in details.items():
-        if val is None:
+        if val is None or val == "null":
             stat(f"null value for {key}")
             return
 


### PR DESCRIPTION
While uploading the review data from semesters 2024A/B, I ran into a few errors due to some new formatting. The changes are summarized below:

- Summary Rows can have some null values for keys such as `RWORKREQUIRED`. When we create ReviewBit objects, we want to ensure that there is at least some data present that we are saving. The assumption is that if we are not given a value for these fields in the summary dump, there are no values to be saved.
- Ratings Rows also now have some null values for keys. Our previously logic was checking if `val is None`, but our parser is not catching these values, so we want to also check for the string `"null"`.
- Date information from this dump came in a new format, `DD-MON-RR`, which required parser support. The `RR` year format isn't supported directly through Python's `datetime` module, so we added an additional function to find the four digit year it corresponds with. More information on this conversion [here](https://pages.di.unipi.it/ghelli/didattica/bdldoc/B19306_01/server.102/b14200/sql_elements004.htm#:~:text=The%20RR%20datetime%20format%20element,two%20digits%20of%20the%20year).