### PR TITLE
Fix Precompute Topics Script for Manually Set Parent Courses

### DIFF
--- a/backend/courses/management/commands/recompute_topics.py
+++ b/backend/courses/management/commands/recompute_topics.py
@@ -53,11 +53,16 @@ def recompute_topics(min_semester: str = None, verbose=False, allow_null_parent_
                 Course.objects.filter(semester=semester)
                 .select_related("parent_course", "parent_course__topic")
                 .prefetch_related("parent_course__children")
+                .order_by("-manually_set_parent_course")
             )
             topics_to_create = []
             topics_to_update = []  # .most_recent
             courses_to_update = []  # .topic
+            visited_courses = set()
+
             for course in courses:
+                if course.id in visited_courses:
+                    continue
                 parent = course.parent_course
                 if not parent:
                     topics_to_create.append(Topic(most_recent=course))
@@ -74,6 +79,11 @@ def recompute_topics(min_semester: str = None, verbose=False, allow_null_parent_
                     parent.full_code == course.full_code
                     and parent.title == course.title
                     or parent.children.count() == 1
+                    or (
+                        sum([child.manually_set_parent_course for child in parent.children.all()])
+                        == 1
+                        and course.manually_set_parent_course
+                    )
                 ):
                     # If a parent has multiple children and none are an exact match, we consider
                     # all the child courses as "branched from" the old. But if one child is an exact
@@ -86,6 +96,7 @@ def recompute_topics(min_semester: str = None, verbose=False, allow_null_parent_
                         topics_to_update.append(course.topic)
                         courses_to_update.append(course)
                 for child in parent.children.all():
+                    visited_courses.add(child.id)
                     if child.id == course.id and not branched_from:
                         continue
                     topics_to_create.append(Topic(most_recent=child, branched_from=parent.topic))

--- a/backend/courses/management/commands/recompute_topics.py
+++ b/backend/courses/management/commands/recompute_topics.py
@@ -32,6 +32,8 @@ def recompute_topics(min_semester: str = None, verbose=False, allow_null_parent_
         - Any single child of a parent inherits the parent's topic.
         - Any child with siblings that exactly matches their parent in full_code
           and title inherits the parent's topic.
+        - Any child with siblings that is the only child with a manually set
+          parent_course_id inherits the parent topic.
         - Any child with siblings that does not exactly match their parent
           gets its own topic.
     These rules are applied sequentially in increasing order of semester.

--- a/backend/review/management/commands/precompute_pcr_views.py
+++ b/backend/review/management/commands/precompute_pcr_views.py
@@ -91,8 +91,10 @@ def precompute_pcr_views(verbose=False, is_new_data=False):
         # Bulk create / update objects.
         if verbose:
             print("Creating and updating objects.")
-        CachedReviewResponse.objects.bulk_create(objs_to_insert)
-        CachedReviewResponse.objects.bulk_update(objs_to_update, ["response", "expired"])
+        CachedReviewResponse.objects.bulk_create(objs_to_insert, batch_size=4000)
+        CachedReviewResponse.objects.bulk_update(
+            objs_to_update, ["response", "expired"], batch_size=4000
+        )
 
         # Bulk delete objects.
         if verbose:


### PR DESCRIPTION
This semester, we saw two major course renumbers in the CIS department – 3800 to 4480 and 3410 to 4521. To quickly modify our database so searches to the new course numbers show reviews from previous numbers, I added the `2024A` offerings of these courses as the parent course for 4480 and 4521 in `2025A`, as well as setting `manually_set_parent_course` to `True`.

While doing this, I noticed some issues with our `recompute_topics` script, which needed to be resolved in order for these course links to show up properly:
- Added a `visited_courses` set to make sure each course is assigned only one topic.
- Added the following role to our topic computation logic: Any child with siblings that is the only child with a manually set `parent_course_id` inherits the parent topic.

After updating the DB and rerunning topic computation, we get the following:
<img width="409" alt="Screenshot 2024-11-12 at 11 29 30 PM" src="https://github.com/user-attachments/assets/6ac3f84a-9c7e-4a75-84c5-79c7e0371ea7">
<img width="500" alt="Screenshot 2024-11-12 at 11 29 45 PM" src="https://github.com/user-attachments/assets/d14593f9-978b-4d8d-a33b-c436a4b936ad">

Also adding `batch_size` for review precomputation.
