### PR TITLE
Add Cronjob for Path Status Sync

### DIFF
--- a/backend/courses/management/commands/sync_path_status.py
+++ b/backend/courses/management/commands/sync_path_status.py
@@ -172,7 +172,7 @@ def resolve_path_differences(send_data_to_slack=False, verbose=False):
             url,
             data=json.dumps(
                 {
-                    "text": f"{len(inconsistent_courses)} inconsistent Course "
+                    "text": f"{len(inconsistent_courses)} Inconsistent Course "
                     + f"Statuses Resolved: {inconsistent_courses}"
                 }
             ),

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -139,6 +139,13 @@ export class MyChart extends PennLabsChart {
 			secret,
 			cmd: ['python', 'manage.py', 'alertstats', '1', '--slack'],
 		})
+
+		new CronJob(this, 'sync-path-course-statuses', {
+			schedule: cronTime.everyHour(),
+			image: backendImage,
+			secret,
+			cmd: ['python', 'manage.py', 'sync_path_status', '--slack'],
+		})
 	}
 }
 


### PR DESCRIPTION
As titled – setting to every hour to ensure at least an every hour guarantee for course statuses. Will merge 11/19 morning.