### PR TITLE
Add Message for Text Notifications

### DIFF
--- a/frontend/alert/components/AlertForm/index.tsx
+++ b/frontend/alert/components/AlertForm/index.tsx
@@ -51,7 +51,10 @@ const ClosedCheckbox = styled.input`
 const closeNotifInfoText = `Check this box to receive a
 follow-up email when a course
 closes again after alerting you
-of an opening.`;
+of an opening. Please note that
+text notifications for course
+closures are not currently
+supported.`;
 
 const doAPIRequest = (
     url: string,


### PR DESCRIPTION
Adding text that clarifies we don't support text notifications for course closures.

<img width="583" alt="Screenshot 2024-11-21 at 10 12 04 AM" src="https://github.com/user-attachments/assets/3d4e50b0-a215-4b65-84fe-1bf74c1d17e3">
