### PR TITLE
pcp showing cart by default instead of map tab on first load

### DIFF
--- a/frontend/plan/pages/index.tsx
+++ b/frontend/plan/pages/index.tsx
@@ -164,11 +164,11 @@ function Index() {
     const [selectedTab, setSelectedTab] = useState<TabItem>(TabItem.Cart);
     useEffect(() => {
         setSelectedTab(
-            router.asPath.split("#")[1] === TabItem.Cart
-                ? TabItem.Cart
+            router.asPath.split("#")[1] === TabItem.Map
+                ? TabItem.Map
                 : router.asPath.split("#")[1] === TabItem.Alerts
                 ? TabItem.Alerts
-                : TabItem.Map
+                : TabItem.Cart
         );
     }, []);
 


### PR DESCRIPTION
Currently, the map tap shows by default on first page load. This is a fine behavior for right now (we want people to know that there is a new map feature), but let's change it back to default cart view as time goes on (i.e. merge after some time) 