### PR TITLE
Fix: Friends’ Schedules Not Displaying Due to Map Feature in PCP

### DIFF
--- a/backend/plan/views.py
+++ b/backend/plan/views.py
@@ -204,6 +204,11 @@ class PrimaryScheduleViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = PrimaryScheduleSerializer
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context.update({"include_location": True})
+        return context
+
     def get_queryset(self):
         return PrimarySchedule.objects.filter(
             Q(user=self.request.user)

--- a/frontend/plan/actions/friendshipUtil.js
+++ b/frontend/plan/actions/friendshipUtil.js
@@ -4,18 +4,18 @@ import getCsrf from "../components/csrf";
 export const SWITCH_ACTIVE_FRIEND = "SWITCH_ACTIVE_FRIEND";
 export const UPDATE_FRIENDSHIPS_ON_FRONTEND = "UPDATE_FRIENDSHIPS_ON_FRONTEND";
 
-export const switchActiveFriend = (friend, found, sections) => ({
+export const switchActiveFriend = (friend, found, schedule) => ({
     type: SWITCH_ACTIVE_FRIEND,
     friend,
     found,
-    sections,
+    schedule,
 });
 
 export const unsetActiveFriend = () => ({
     type: SWITCH_ACTIVE_FRIEND,
     friend: null,
     found: null,
-    sections: null,
+    schedule: null,
 });
 
 export const updateFriendshipsOnFrontend = (
@@ -129,11 +129,11 @@ export const fetchFriendPrimarySchedule = (friend) => (dispatch) => {
                     switchActiveFriend(
                         foundSched.user,
                         true,
-                        foundSched.schedule.sections
+                        foundSched.schedule
                     )
                 );
             } else {
-                dispatch(switchActiveFriend(friend, false, []));
+                dispatch(switchActiveFriend(friend, false, {}));
             }
             dispatch(setStateReadOnly(true));
         })

--- a/frontend/plan/components/map/MapRadio.tsx
+++ b/frontend/plan/components/map/MapRadio.tsx
@@ -58,6 +58,7 @@ export default function MapDropdown({
         <RadioContainer>
             {Object.keys(DAYS_TO_DAYSTRINGS).map((day) => (
                 <Radio
+                    key={day}
                     $isSelected={selectedDay === day}
                     onClick={() => {
                         setSelectedDay(day as Day);

--- a/frontend/plan/components/schedule/Schedule.tsx
+++ b/frontend/plan/components/schedule/Schedule.tsx
@@ -26,7 +26,7 @@ import {
     deleteFriendshipOnBackend,
     fetchBackendFriendships,
     fetchFriendPrimarySchedule,
-    unsetActiveFriend
+    unsetActiveFriend,
 } from "../../actions/friendshipUtil";
 
 const ScheduleContainer = styled.div`
@@ -61,10 +61,7 @@ interface ScheduleProps {
     friendshipMutators: {
         fetchFriendSchedule: (friend: User) => void;
         fetchBackendFriendships: (user: User) => void;
-        deleteFriendshipOnBackend: (
-            user: User,
-            friendPennkey: string
-        ) => void;
+        deleteFriendshipOnBackend: (user: User, friendPennkey: string) => void;
     };
     schedulesMutator: {
         setPrimary: (user: User, scheduleId: string | null) => void;
@@ -150,12 +147,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<any, any, any>) => ({
             dispatch(fetchFriendPrimarySchedule(friend)),
         fetchBackendFriendships: (user: User) =>
             dispatch(fetchBackendFriendships(user)),
-        deleteFriendshipOnBackend: (
-            user: User,
-            friendPennkey: string) =>
-            dispatch(
-                deleteFriendshipOnBackend(user, friendPennkey)
-            ),
+        deleteFriendshipOnBackend: (user: User, friendPennkey: string) =>
+            dispatch(deleteFriendshipOnBackend(user, friendPennkey)),
     },
     schedulesMutator: {
         setPrimary: (user: User, scheduleId: string | null) =>

--- a/frontend/plan/components/schedule/ScheduleDisplay.tsx
+++ b/frontend/plan/components/schedule/ScheduleDisplay.tsx
@@ -118,7 +118,6 @@ const ScheduleDisplay = ({
 }: ScheduleDisplayProps) => {
     // actual schedule elements are offset by the row/col offset since
     // days/times take up a row/col respectively.
-
     if (!schedData) {
         return (
             <ScheduleBox>

--- a/frontend/plan/components/schedule/ScheduleSelectorDropdown.tsx
+++ b/frontend/plan/components/schedule/ScheduleSelectorDropdown.tsx
@@ -1,12 +1,21 @@
 import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { Icon } from "../bulma_derived_components";
-import { User, Schedule as ScheduleType, Color, FriendshipState, Section } from "../../types";
+import {
+    User,
+    Schedule as ScheduleType,
+    Color,
+    FriendshipState,
+    Section,
+} from "../../types";
 import { nextAvailable } from "../../reducers/schedule";
 import NewLabel from "../common/NewLabel";
 import { PATH_REGISTRATION_SCHEDULE_NAME } from "../../constants/constants";
 
-const ButtonContainer = styled.div<{ $isActive: boolean; $isPrimary?: boolean }>`
+const ButtonContainer = styled.div<{
+    $isActive: boolean;
+    $isPrimary?: boolean;
+}>`
     line-height: 1.5;
     position: relative;
     border-radius: 0 !important;
@@ -43,7 +52,7 @@ const ButtonContainer = styled.div<{ $isActive: boolean; $isPrimary?: boolean }>
 
     .option-icon i.primary:hover {
         color: ${(props) =>
-        props.$isPrimary ? "#295FCE" : "#7E7E7E"}; !important;
+            props.$isPrimary ? "#295FCE" : "#7E7E7E"}; !important;
     }
 
     .initial-icon {
@@ -86,7 +95,7 @@ interface FriendButtonProps {
     isActive: boolean;
     display: () => void;
     removeFriend: () => void;
-    color: Color
+    color: Color;
 }
 
 const FriendButton = ({
@@ -94,7 +103,7 @@ const FriendButton = ({
     isActive,
     display,
     removeFriend,
-    color
+    color,
 }: FriendButtonProps) => (
     <ButtonContainer $isActive={isActive} onClick={display}>
         <InitialIcon $color={color}>
@@ -171,22 +180,25 @@ const DropdownButton = ({
                     className="option-icon"
                 >
                     <i
-                        className={`primary ${isPrimary ? "fa" : "far"
-                            } fa-user`}
+                        className={`primary ${
+                            isPrimary ? "fa" : "far"
+                        } fa-user`}
                         aria-hidden="true"
                     />
                 </Icon>
             )}
-            {rename && <Icon
-                onClick={(e) => {
-                    rename();
-                    e.stopPropagation();
-                }}
-                role="button"
-                className="option-icon"
-            >
-                <i className="far fa-edit" aria-hidden="true" />
-            </Icon>}
+            {rename && (
+                <Icon
+                    onClick={(e) => {
+                        rename();
+                        e.stopPropagation();
+                    }}
+                    role="button"
+                    className="option-icon"
+                >
+                    <i className="far fa-edit" aria-hidden="true" />
+                </Icon>
+            )}
             <Icon
                 onClick={(e) => {
                     copy();
@@ -208,16 +220,18 @@ const DropdownButton = ({
             >
                 <i className="fa fa-download" aria-hidden="true" />
             </Icon> */}
-            {remove && <Icon
-                onClick={(e) => {
-                    remove();
-                    e.stopPropagation();
-                }}
-                role="button"
-                className="option-icon"
-            >
-                <i className="fa fa-trash" aria-hidden="true" />
-            </Icon>}
+            {remove && (
+                <Icon
+                    onClick={(e) => {
+                        remove();
+                        e.stopPropagation();
+                    }}
+                    role="button"
+                    className="option-icon"
+                >
+                    <i className="fa fa-trash" aria-hidden="true" />
+                </Icon>
+            )}
         </ScheduleOptionsContainer>
     </ButtonContainer>
 );
@@ -249,7 +263,7 @@ const DropdownTrigger = styled.div`
 
 const DropdownMenu = styled.div<{ $isActive: boolean }>`
     margin-top: 0.1rem !important;
-    display: ${({ $isActive }) => $isActive ? "block" : "none"};
+    display: ${({ $isActive }) => ($isActive ? "block" : "none")};
     left: 0;
     min-width: 15rem;
     padding-top: 4px;
@@ -339,18 +353,18 @@ const PendingRequestsNum = styled.div`
     color: white;
     font-size: 0.68rem;
     align-items: center;
-`
+`;
 
 const ScheduleDropdownHeader = styled.div`
     display: flex;
     position: relative;
     width: 100%;
-`
+`;
 
 const ShareSchedulePromoContainer = styled.div`
     display: flex;
     margin-left: auto;
-`
+`;
 
 const ShareSchedulePromo = styled.div`
     display: flex;
@@ -363,9 +377,9 @@ const ShareSchedulePromo = styled.div`
     font-weight: 500;
     justify-content: start;
     padding: 0 0.5rem 0 0.5rem;
-    user-select: none; 
+    user-select: none;
     margin-left: 0.5rem;
-`
+`;
 
 const ReceivedRequestNotice = styled.div`
     background-color: #e58d8d;
@@ -376,7 +390,7 @@ const ReceivedRequestNotice = styled.div`
     position: relative;
     top: 0;
     right: 0.2rem;
-`
+`;
 
 const DropdownTriggerContainer = styled.div<{ $isActive: boolean }>`
     display: flex;
@@ -387,7 +401,7 @@ const DropdownTriggerContainer = styled.div<{ $isActive: boolean }>`
     :hover {
         background: rgba(175, 194, 255, 0.27);
     }
-`
+`;
 
 interface ScheduleSelectorDropdownProps {
     user: User;
@@ -400,9 +414,7 @@ interface ScheduleSelectorDropdownProps {
     friendshipMutators: {
         fetchFriendSchedule: (friend: User) => void;
         fetchBackendFriendships: (user: User) => void;
-        deleteFriendshipOnBackend: (
-            user: User,
-            friendPennkey: string) => void;
+        deleteFriendshipOnBackend: (user: User, friendPennkey: string) => void;
     };
     schedulesMutators: {
         copy: (scheduleName: string, sections: Section[]) => void;
@@ -508,39 +520,52 @@ const ScheduleSelectorDropdown = ({
     return (
         <ScheduleDropdownContainer ref={ref}>
             <ScheduleDropdownHeader>
-                <DropdownTriggerContainer 
+                <DropdownTriggerContainer
                     $isActive={isActive}
-                        onClick={() => {
-                            fetchBackendFriendships(
-                                user);
-                            setIsActive(!isActive);
-                        }}
-                        role="button">
+                    onClick={() => {
+                        fetchBackendFriendships(user);
+                        setIsActive(!isActive);
+                    }}
+                    role="button"
+                >
                     <span className="selected_name">
                         {readOnly && friendshipState.activeFriend
-                            ? friendshipState.activeFriend.first_name + "'s Schedule"
+                            ? friendshipState.activeFriend.first_name +
+                              "'s Schedule"
                             : activeName}
                     </span>
                     <DropdownTrigger>
                         <div aria-haspopup={true} aria-controls="dropdown-menu">
                             <Icon>
-                                <i className={`fa fa-chevron-${isActive ? "up" : "down"}`} aria-hidden="true"/>
+                                <i
+                                    className={`fa fa-chevron-${
+                                        isActive ? "up" : "down"
+                                    }`}
+                                    aria-hidden="true"
+                                />
                             </Icon>
                         </div>
                     </DropdownTrigger>
-                    {numRequests > 0 && <ReceivedRequestNotice/>}
+                    {numRequests > 0 && <ReceivedRequestNotice />}
                 </DropdownTriggerContainer>
-                {(!readOnly || !friendshipState.activeFriend) && <ShareSchedulePromoContainer>
-                    <NewLabel />
-                    <ShareSchedulePromo onClick={() => setIsActive(!isActive)}>
-                        <img
-                            style={{ width: "1.3rem", paddingRight: "0.3rem" }}
-                            src="/icons/share.svg"
-                            alt="share"
-                        />
-                        Share Schedule
-                    </ShareSchedulePromo>
-                </ShareSchedulePromoContainer>}
+                {(!readOnly || !friendshipState.activeFriend) && (
+                    <ShareSchedulePromoContainer>
+                        <NewLabel />
+                        <ShareSchedulePromo
+                            onClick={() => setIsActive(!isActive)}
+                        >
+                            <img
+                                style={{
+                                    width: "1.3rem",
+                                    paddingRight: "0.3rem",
+                                }}
+                                src="/icons/share.svg"
+                                alt="share"
+                            />
+                            Share Schedule
+                        </ShareSchedulePromo>
+                    </ShareSchedulePromoContainer>
+                )}
             </ScheduleDropdownHeader>
             <DropdownMenu $isActive={isActive} role="menu">
                 <DropdownContent>
@@ -549,31 +574,45 @@ const ScheduleSelectorDropdown = ({
                             .sort(([nameA, dataA], [nameB, dataB]) => {
                                 /* Always putting primary schedule at the top, followed by the path registration schedule,
                                  * then rest of schedules should be ordered by created_at
-                                */ 
-                                
+                                 */
+
                                 if (dataA.id === primaryScheduleId) return -1;
                                 if (dataB.id === primaryScheduleId) return 1;
-                                if (nameA == PATH_REGISTRATION_SCHEDULE_NAME) return -1; 
-                                if (nameB === PATH_REGISTRATION_SCHEDULE_NAME) return -1; 
-                                
-                                return dataA.created_at < dataB.created_at ? -1 : 1;
+                                if (nameA == PATH_REGISTRATION_SCHEDULE_NAME)
+                                    return -1;
+                                if (nameB === PATH_REGISTRATION_SCHEDULE_NAME)
+                                    return -1;
+
+                                return dataA.created_at < dataB.created_at
+                                    ? -1
+                                    : 1;
                             })
                             .map(([name, data]) => {
-                                const mutable = name !== PATH_REGISTRATION_SCHEDULE_NAME;
+                                const mutable =
+                                    name !== PATH_REGISTRATION_SCHEDULE_NAME;
                                 return (
                                     <DropdownButton
                                         key={data.id}
-                                        isActive={name === activeName}
+                                        isActive={
+                                            name === activeName &&
+                                            friendshipState.activeFriend ===
+                                                null
+                                        }
                                         makeActive={() => {
                                             setIsActive(false);
                                         }}
-                                        isPrimary={primaryScheduleId === data.id}
+                                        isPrimary={
+                                            primaryScheduleId === data.id
+                                        }
                                         hasFriends={hasFriends}
                                         onClick={() => displayOwnSchedule(name)}
                                         text={name}
                                         mutators={{
                                             setPrimary: () => {
-                                                if (primaryScheduleId === data.id) {
+                                                if (
+                                                    primaryScheduleId ===
+                                                    data.id
+                                                ) {
                                                     setPrimary(user, null);
                                                 } else {
                                                     setPrimary(user, data.id);
@@ -586,11 +625,20 @@ const ScheduleSelectorDropdown = ({
                                                         allSchedules
                                                     ),
                                                     data.sections
-                                                )
+                                                );
                                             },
                                             download: () => download(name),
-                                            remove: mutable ? (() => remove(user, name, data.id)) : null,
-                                            rename: mutable ? (() => rename(name)) : null,
+                                            remove: mutable
+                                                ? () =>
+                                                      remove(
+                                                          user,
+                                                          name,
+                                                          data.id
+                                                      )
+                                                : null,
+                                            rename: mutable
+                                                ? () => rename(name)
+                                                : null,
                                         }}
                                     />
                                 );
@@ -619,20 +667,22 @@ const ScheduleSelectorDropdown = ({
                                 "Add a friend to share a schedule"
                             )}
                         </div>
-                        {friendshipState.acceptedFriends.map((friend) => (
+                        {friendshipState.acceptedFriends.map((friend, i) => (
                             <FriendButton
+                                key={i}
                                 friendName={`${friend.first_name} ${friend.last_name}`}
                                 display={() => fetchFriendSchedule(friend)}
                                 removeFriend={() => {
                                     deleteFriendshipOnBackend(
                                         user,
-                                        friend.username);
+                                        friend.username
+                                    );
                                 }}
                                 isActive={
                                     readOnly &&
                                     friendshipState.activeFriend &&
                                     friendshipState.activeFriend.username ===
-                                    friend.username
+                                        friend.username
                                 }
                                 color={getColor(friend.username)}
                             />
@@ -649,7 +699,9 @@ const ScheduleSelectorDropdown = ({
                             href="#"
                         >
                             <span> Pending Requests </span>
-                            <PendingRequestsNum>{numRequests}</PendingRequestsNum>
+                            <PendingRequestsNum>
+                                {numRequests}
+                            </PendingRequestsNum>
                         </PendingRequests>
                     </FriendContent>
                 </DropdownContent>

--- a/frontend/plan/reducers/friendships.js
+++ b/frontend/plan/reducers/friendships.js
@@ -2,6 +2,7 @@ import {
     UPDATE_FRIENDSHIPS_ON_FRONTEND,
     SWITCH_ACTIVE_FRIEND,
 } from "../actions/friendshipUtil";
+import { Color } from "../types";
 
 const initialState = {
     pulledFromBackend: false,
@@ -25,16 +26,71 @@ const handleUpdateFriendsOnFrontend = (state, action) => {
     return newState;
 };
 
+// Used for box coloring, from StackOverflow:
+// https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
+const hashString = (s) => {
+    let hash = 0;
+    if (!s || s.length === 0) return hash;
+    for (let i = 0; i < s.length; i += 1) {
+        const chr = s.charCodeAt(i);
+        hash = (hash << 5) - hash + chr;
+        hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+};
+
+// step 2 in the CIS121 review: hashing with linear probing.
+// hash every section to a color, but if that color is taken, try the next color in the
+// colors array. Only start reusing colors when all the colors are used.
+const getColor = (() => {
+    const colors = [
+        Color.BLUE,
+        Color.RED,
+        Color.AQUA,
+        Color.ORANGE,
+        Color.GREEN,
+        Color.PINK,
+        Color.SEA,
+        Color.INDIGO,
+    ];
+    // some CIS120: `used` is a *closure* storing the colors currently in the schedule
+    let used = [];
+    return (c) => {
+        if (used.length === colors.length) {
+            // if we've used all the colors, it's acceptable to start reusing colors.
+            used = [];
+        }
+        let i = Math.abs(hashString(c));
+        while (used.indexOf(colors[i % colors.length]) !== -1) {
+            i += 1;
+        }
+        const color = colors[i % colors.length];
+        used.push(color);
+        return color;
+    };
+})();
+
 export const friendships = (state = initialState, action) => {
     switch (action.type) {
         case SWITCH_ACTIVE_FRIEND:
             return {
                 ...state,
                 activeFriend: action.friend,
-                activeFriendSchedule: {
-                    found: action.found,
-                    sections: action.sections,
-                },
+                activeFriendSchedule: action.schedule
+                    ? {
+                          found: action.found,
+                          sections: action.schedule.sections.map((section) => ({
+                              ...section,
+                              color: getColor(section.id),
+                          })),
+                          id: action.schedule.id,
+                          pushedToBackend: true,
+                          updated_at: Date.now(),
+                          created_at: new Date(
+                              action.schedule.created_at
+                          ).getTime(),
+                      }
+                    : null,
             };
         case UPDATE_FRIENDSHIPS_ON_FRONTEND:
             return handleUpdateFriendsOnFrontend(state, action);

--- a/frontend/shared-components/src/accounts/LoginButton.tsx
+++ b/frontend/shared-components/src/accounts/LoginButton.tsx
@@ -45,7 +45,7 @@ const LoginButton: React.FC<{
     return (
         <LoginButtonStyles
             $noMargin={noMargin ?? false}
-            href={`/accounts/login/?next=${pathname}`}
+            href={`/accounts/login/?next=${pathname.replace("/", "")}`}
         >
             Login
         </LoginButtonStyles>

--- a/frontend/shared-components/src/accounts/UserSelector.js
+++ b/frontend/shared-components/src/accounts/UserSelector.js
@@ -86,10 +86,10 @@ const LogoutDropdownMenu = styled.div`
     display: ${({ selected }) => (selected ? "block" : "none")};
     left: 0;
     min-width: 12rem;
-    ${({ floatTop }) =>
-        floatTop ? "padding-bottom: 4px" : "padding-top: 4px"};
+    ${({ floattop }) =>
+        floattop ? "padding-bottom: 4px" : "padding-top: 4px"};
     position: absolute;
-    ${({ floatTop }) => (floatTop ? "bottom: 100%" : "top: 100%")};
+    ${({ floattop }) => (floattop ? "bottom: 100%" : "top: 100%")};
     z-index: 20;
 `;
 
@@ -137,9 +137,12 @@ const UserSelector = ({
                         "U"}{" "}
                 </span>
             </NameBubble>
-            <LogoutDropdownMenu selected={selected} floatTop={dropdownTop}>
+            <LogoutDropdownMenu
+                selected={selected}
+                floattop={dropdownTop.toString()}
+            >
                 <LogoutDropdownContainer className="dropdown-menu-container">
-                    <TriangleUp down={dropdownTop} />
+                    <TriangleUp down={dropdownTop.toString()} />
                     <InnerMenu $leftAligned={leftAligned}>
                         <NameContainer>
                             {" "}


### PR DESCRIPTION
**Description:**
The recent addition of the map feature in PCP introduced a bug where users were unable to view their friends’ schedules. This issue affected the rendering logic, preventing schedules from being properly displayed. The issue primarily stemmed from the course colors (colors used to display course blocks/map pins) not being properly assigned to friends' courses, and also not distinguishing between a friend's schedule and the current user's schedule when displaying the map for the "active" schedule. 

This PR includes a fix that:
- Assigns colors to a selected friend's courses upon retrieval
- Adding a check in the map component to be able to display the active schedule correctly (whether it is the current user's schedule or a friend's)

**Screenshots**:
![Screenshot 2025-03-15 at 9 32 56 PM](https://github.com/user-attachments/assets/c7c1879c-6fc0-4659-b0ba-58ac8e3bdb0a)
![Screenshot 2025-03-15 at 9 33 03 PM](https://github.com/user-attachments/assets/2e8c1900-c87e-4baf-a1b0-009fe6b986d5)

