### PR TITLE
Refactor breaks to persist across schedules

### DIFF
--- a/backend/courses/util.py
+++ b/backend/courses/util.py
@@ -467,16 +467,13 @@ def clean_meetings(meetings):
 
 
 def set_meetings(obj, meetings):
-    print("meetings", meetings)
     meetings = clean_meetings(meetings)
-    print("meetings", meetings)
 
     for meeting in meetings:
         meeting["days"] = "".join(sorted(list(set(meeting["days"]))))
     meeting_times = [
         f"{meeting['days']} {meeting['begin_time']} - {meeting['end_time']}" for meeting in meetings
     ]
-    print("meeting_times", meeting_times)
     obj.meeting_times = json.dumps(meeting_times)
 
     obj.meetings.all().delete()
@@ -492,12 +489,10 @@ def set_meetings(obj, meetings):
         )
         room = None if online else get_room(meeting["building_code"], meeting["room_code"])
         start_time = Decimal(meeting["begin_time_24"]) / 100
-        print(start_time)
         end_time = Decimal(meeting["end_time_24"]) / 100
         start_date = extract_date(meeting.get("start_date"))
         end_date = extract_date(meeting.get("end_date"))
         for day in list(meeting["days"]):
-
             meeting = Meeting.objects.update_or_create(
                 section=obj if isinstance(obj, Section) else None,
                 associated_break=obj if isinstance(obj, Break) else None,

--- a/backend/plan/views.py
+++ b/backend/plan/views.py
@@ -670,6 +670,15 @@ class BreakViewSet(AutoPrefetchViewSetMixin, viewsets.ModelViewSet):
         # context.update({"include_location": eval(include_location_str)})
         return context
 
+    def get(self):
+        """
+        Get all breaks for the current user.
+        """
+        breaks = self.get_queryset()
+        serializer = BreakSerializer(breaks, many=True, context=self.get_serializer_context())
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
     def update(self, request, *args, **kwargs):
         break_id = kwargs["pk"]
         if not break_id:
@@ -729,8 +738,15 @@ class BreakViewSet(AutoPrefetchViewSetMixin, viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         break_id = request.data.get("id")
+        print(Break.objects.filter(person=request.user))
         if break_id and Break.objects.filter(id=break_id).exists():
             return self.update(request, pk=break_id)
+
+        if Break.objects.filter(person=request.user).count() >= 10:
+            print(Break.objects.filter(person=request.user))
+            return Response(
+                {"detail": "You can only have up to 10 breaks."}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         name = request.data.get("name")
         if not name:

--- a/backend/plan/views.py
+++ b/backend/plan/views.py
@@ -678,7 +678,6 @@ class BreakViewSet(AutoPrefetchViewSetMixin, viewsets.ModelViewSet):
         serializer = BreakSerializer(breaks, many=True, context=self.get_serializer_context())
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-
     def update(self, request, *args, **kwargs):
         break_id = kwargs["pk"]
         if not break_id:

--- a/frontend/plan/actions/index.js
+++ b/frontend/plan/actions/index.js
@@ -72,6 +72,7 @@ export const SET_PRIMARY_SCHEDULE_ID_ON_FRONTEND =
     "SET_PRIMARY_SCHEDULE_ID_ON_FRONTEND";
 
 export const ADD_BREAK_ITEM = "ADD_BREAK_ITEM";
+export const ADD_BREAK = "ADD_BREAK";
 export const TOGGLE_BREAK = "TOGGLE_BREAK";
 export const REMOVE_BREAK = "REMOVE_BREAK";
 
@@ -552,6 +553,21 @@ export const updateContactInfoFrontend = (contactInfo) => ({
     contactInfo,
 });
 
+export const addBreakFrontend = (breakItem) => ({
+    type: ADD_BREAK,
+    breakItem,
+});
+
+export const toggleBreakFrontend = (breakItem) => ({
+    type: TOGGLE_BREAK,
+    breakItem,
+});
+
+export const removeBreakFrontend = (breakId) => ({
+    type: REMOVE_BREAK,
+    breakId,
+});
+
 export const markAlertsSynced = () => ({
     type: MARK_ALERTS_SYNCED,
 });
@@ -643,7 +659,8 @@ function convertToHHMM(decimalHour) {
     return hours * 100 + minutes;
 }
 
-export const createBreakItemBackend = (name, days, timeRange) => (dispatch) => {
+
+export const createBreakBackend = (name, days, timeRange) => (dispatch) => {
     doAPIRequest("/plan/breaks/", {
         method: "POST",
         credentials: "include",
@@ -669,12 +686,12 @@ export const createBreakItemBackend = (name, days, timeRange) => (dispatch) => {
         }),
     })
         .then((res) => res.json())
-        .then((breakItem) => {
-            dispatch(addBreakItem(name, days, timeRange, breakItem.break_id));
+        .then((breakData) => {
+            dispatch(fetchBreaks(breakData.break_id)); 
         });
 };
 
-export const removeBreakItemBackend = (breakId) => (dispatch) => {
+export const removeBreakBackend = (breakId) => (dispatch) => {
     doAPIRequest(`/plan/breaks/${breakId}/`, {
         method: "DELETE",
         credentials: "include",
@@ -1058,3 +1075,22 @@ export const updateContactInfo = (contactInfo) => (dispatch) => {
         }
     });
 };
+
+export const fetchBreaks = (breakId = null) => (dispatch) => {
+    doAPIRequest("/plan/breaks/")
+        .then((res) => res.json())
+        .then((breaks) => {
+            breaks.forEach((breakItem) => {
+                dispatch(
+                    addBreakFrontend(breakItem)
+                )
+            })
+            return breaks;
+        }).then((breaks) => {
+            if (breakId !== null) {
+                dispatch(toggleBreakFrontend(breaks.find((breakItem) => breakItem.id === breakId)));
+            }
+        })
+        // eslint-disable-next-line no-console
+        .catch((error) => console.log(error));
+}

--- a/frontend/plan/actions/index.js
+++ b/frontend/plan/actions/index.js
@@ -659,7 +659,6 @@ function convertToHHMM(decimalHour) {
     return hours * 100 + minutes;
 }
 
-
 export const createBreakBackend = (name, days, timeRange) => (dispatch) => {
     doAPIRequest("/plan/breaks/", {
         method: "POST",
@@ -687,7 +686,7 @@ export const createBreakBackend = (name, days, timeRange) => (dispatch) => {
     })
         .then((res) => res.json())
         .then((breakData) => {
-            dispatch(fetchBreaks(breakData.break_id)); 
+            dispatch(fetchBreaks(breakData.break_id));
         });
 };
 
@@ -1081,16 +1080,19 @@ export const fetchBreaks = (breakId = null) => (dispatch) => {
         .then((res) => res.json())
         .then((breaks) => {
             breaks.forEach((breakItem) => {
-                dispatch(
-                    addBreakFrontend(breakItem)
-                )
-            })
+                dispatch(addBreakFrontend(breakItem));
+            });
             return breaks;
-        }).then((breaks) => {
+        })
+        .then((breaks) => {
             if (breakId !== null) {
-                dispatch(toggleBreakFrontend(breaks.find((breakItem) => breakItem.id === breakId)));
+                dispatch(
+                    toggleBreakFrontend(
+                        breaks.find((breakItem) => breakItem.id === breakId)
+                    )
+                );
             }
         })
         // eslint-disable-next-line no-console
         .catch((error) => console.log(error));
-}
+};

--- a/frontend/plan/components/schedule/Schedule.tsx
+++ b/frontend/plan/components/schedule/Schedule.tsx
@@ -21,7 +21,6 @@ import {
   User,
   Schedule as ScheduleType,
   FriendshipState,
-  BreakSectionItem,
 } from "../../types";
 import ScheduleDisplay from "./ScheduleDisplay";
 import {
@@ -50,7 +49,7 @@ const ScheduleDropdownHeader = styled.h3`
 interface ScheduleProps {
   user: User;
   activeScheduleName: string;
-  currScheduleData: { sections: Section[], breaks: BreakSectionItem[] };
+  currScheduleData: { sections: Section[], breaks: Break[] };
   allSchedules: ScheduleType[];
   primaryScheduleId: string;
   readOnly: boolean;

--- a/frontend/plan/components/schedule/ScheduleDisplay.tsx
+++ b/frontend/plan/components/schedule/ScheduleDisplay.tsx
@@ -14,7 +14,6 @@ import {
   Break,
   MeetingBlock,
   FriendshipState,
-  BreakSectionItem,
 } from "../../types";
 import { getConflictGroups } from "../meetUtil";
 import { PATH_REGISTRATION_SCHEDULE_NAME } from "../../constants/constants";
@@ -101,7 +100,7 @@ interface ScheduleDisplayProps {
   schedName: string;
   schedData: {
     sections: Section[];
-    breaks: BreakSectionItem[];
+    breaks: Break[];
   };
   friendshipState: FriendshipState;
   focusSection: (id: string) => void;
@@ -158,8 +157,8 @@ const ScheduleDisplay = ({
         (meeting: Meeting) => meeting.day === "S" || meeting.day === "U"
       )
     ) ||
-    breaks.some((brk: BreakSectionItem) =>
-      brk.break.meetings?.some(
+    breaks.some((brk: Break) =>
+      brk.meetings?.some(
         (meeting: Meeting) => meeting.day === "S" || meeting.day === "U"
       )
     );
@@ -199,19 +198,17 @@ const ScheduleDisplay = ({
     }
   });
 
-  breaks.forEach((b) => {
-    if (b.checked) {
-      let breakItem = b.break;
-      if (breakItem.meetings) {
+  breaks.forEach((b: Break) => {
+      if (b.meetings) {
         meetings.push(
-          ...breakItem.meetings.map((m) => ({
+          ...b.meetings.map((m) => ({
             day: m.day as Day,
             start: transformTime(m.start),
             end: transformTime(m.end),
             type: "break",
             course: {
-              color: breakItem.color,
-              id: breakItem.name,
+              color: b.color,
+              id: b.name,
               coreqFulfilled: true
             },
             style: {
@@ -220,7 +217,6 @@ const ScheduleDisplay = ({
             },
           }))
         );
-      }
     }
   });
 

--- a/frontend/plan/components/syncutils.js
+++ b/frontend/plan/components/syncutils.js
@@ -8,6 +8,7 @@ import {
     checkForDefaultSchedules,
     fetchContactInfo,
     fetchAlerts,
+    fetchBreaks,
 } from "../actions";
 import { fetchBackendFriendships } from "../actions/friendshipUtil";
 import { SYNC_INTERVAL } from "../constants/sync_constants";
@@ -140,6 +141,7 @@ const initiateSync = async (store) => {
         // run on initial page load, but not during sync loop
         await store.dispatch(fetchContactInfo());
         await store.dispatch(fetchAlerts());
+        await store.dispatch(fetchBreaks());
         while (store.getState().login.user) {
             // ensure that the minimum distance between syncs is SYNC_INTERVAL
             // eslint-disable-next-line no-await-in-loop

--- a/frontend/plan/reducers/breaks.js
+++ b/frontend/plan/reducers/breaks.js
@@ -1,0 +1,38 @@
+import { ADD_BREAK, REMOVE_BREAK, UPDATE_BREAK } from '../actions';
+
+const initialState = {
+    breaks: [],
+    loading: false,
+};
+
+export const breaks = (state = initialState, { type, ...action }) => {
+   switch (type) {
+        case ADD_BREAK:
+            if (!action.breakItem) {
+                return state; // No break item to add
+            }
+            if (state.breaks.some(b => b.id === action.breakItem.id)) {
+                return state; // Break already exists
+            }
+            return {
+                ...state,
+                breaks: [...state.breaks, action.breakItem],
+            };
+        case REMOVE_BREAK:
+            return {
+                ...state,
+                breaks: state.breaks.filter((b) => b.id !== action.id),
+            };
+        case UPDATE_BREAK:
+            return {
+                ...state,
+                breaks: state.breaks.map((b) =>
+                    b.id === action.breakItem.id ? action.breakItem : b
+                ),
+            };
+        default:
+            return {
+                ...state,
+            };
+    } 
+}

--- a/frontend/plan/reducers/breaks.js
+++ b/frontend/plan/reducers/breaks.js
@@ -1,4 +1,4 @@
-import { ADD_BREAK, REMOVE_BREAK, UPDATE_BREAK } from '../actions';
+import { ADD_BREAK, REMOVE_BREAK } from "../actions";
 
 const initialState = {
     breaks: [],
@@ -6,12 +6,12 @@ const initialState = {
 };
 
 export const breaks = (state = initialState, { type, ...action }) => {
-   switch (type) {
+    switch (type) {
         case ADD_BREAK:
             if (!action.breakItem) {
                 return state; // No break item to add
             }
-            if (state.breaks.some(b => b.id === action.breakItem.id)) {
+            if (state.breaks.some((b) => b.id === action.breakItem.id)) {
                 return state; // Break already exists
             }
             return {
@@ -23,16 +23,9 @@ export const breaks = (state = initialState, { type, ...action }) => {
                 ...state,
                 breaks: state.breaks.filter((b) => b.id !== action.id),
             };
-        case UPDATE_BREAK:
-            return {
-                ...state,
-                breaks: state.breaks.map((b) =>
-                    b.id === action.breakItem.id ? action.breakItem : b
-                ),
-            };
         default:
             return {
                 ...state,
             };
-    } 
-}
+    }
+};

--- a/frontend/plan/reducers/index.js
+++ b/frontend/plan/reducers/index.js
@@ -16,7 +16,7 @@ const coursePlanApp = combineReducers({
     login,
     friendships,
     alerts,
-    breaks
+    breaks,
 });
 
 export default coursePlanApp;

--- a/frontend/plan/reducers/index.js
+++ b/frontend/plan/reducers/index.js
@@ -6,6 +6,7 @@ import { filters } from "./filters";
 import { login } from "./login";
 import { friendships } from "./friendships";
 import { alerts } from "./alerts";
+import { breaks } from "./breaks";
 
 const coursePlanApp = combineReducers({
     schedule,
@@ -15,6 +16,7 @@ const coursePlanApp = combineReducers({
     login,
     friendships,
     alerts,
+    breaks
 });
 
 export default coursePlanApp;

--- a/frontend/plan/reducers/schedule.js
+++ b/frontend/plan/reducers/schedule.js
@@ -17,9 +17,7 @@ import {
     REMOVE_SCHED_ITEM,
     ADD_CART_ITEM,
     REMOVE_CART_ITEM,
-    ADD_BREAK_ITEM,
     TOGGLE_BREAK,
-    REMOVE_BREAK,
 } from "../actions";
 import { scheduleContainsSection } from "../components/meetUtil";
 import { showToast } from "../pages";
@@ -331,7 +329,6 @@ export const schedule = (state = initialState, action) => {
             return {
                 ...state,
                 schedules: {
-       
                     ...removeSchedule(action.oldName, state.schedules),
                     [action.newName]: {
                         ...state.schedules[action.oldName],
@@ -422,7 +419,7 @@ export const schedule = (state = initialState, action) => {
             }
             if (state.scheduleSelected === PATH_REGISTRATION_SCHEDULE_NAME) {
                 showToast("Cannot edit Path registration here!", true);
-            } else {schedules[scheduleSelected]?.breaks ?? [],
+            } else {
                 showToast("Cannot change a friend's schedule!", true);
             }
 
@@ -476,12 +473,19 @@ export const schedule = (state = initialState, action) => {
                 const oldBreakSections =
                     state.schedules[state.scheduleSelected]?.breaks ?? [];
                 let newBreakSections;
-                if (oldBreakSections.some(br => br.id === action.breakItem.id)) {
-                    newBreakSections = oldBreakSections.filter((br) => br.id !== action.breakItem.id);
+                if (
+                    oldBreakSections.some((br) => br.id === action.breakItem.id)
+                ) {
+                    newBreakSections = oldBreakSections.filter(
+                        (br) => br.id !== action.breakItem.id
+                    );
                 } else {
                     newBreakSections = [
                         ...oldBreakSections,
-                        {...action.breakItem, color: getColor(action.breakItem.name)},
+                        {
+                            ...action.breakItem,
+                            color: getColor(action.breakItem.name),
+                        },
                     ];
                 }
                 const temp = {

--- a/frontend/plan/types.ts
+++ b/frontend/plan/types.ts
@@ -176,11 +176,6 @@ export interface CartCourse {
     overlaps: boolean;
 }
 
-export interface BreakSectionItem {
-    break: Break;
-    checked: boolean;
-}
-
 export interface CoursesByDay {
     M: CartCourse[];
     T: CartCourse[];
@@ -194,7 +189,7 @@ export interface CoursesByDay {
 export interface Schedule {
     id: string;
     sections: Section[];
-    breaks: BreakSectionItem[];
+    breaks: Break[];
     semester: string;
     name: string;
     created_at: string;
@@ -253,7 +248,7 @@ export type FilterType =
 
     export interface FriendshipState {
         activeFriend: User;
-        activeFriendSchedule: { found: boolean; sections: Section[], breaks: BreakSectionItem[] };
+        activeFriendSchedule: { found: boolean; sections: Section[], breaks: Break[] };
         acceptedFriends: User[];
         requestsReceived: Friendship[];
         requestsSent: Friendship[];


### PR DESCRIPTION
- "Break cart" now is tied to a user, rather than an individual schedule
- Added new individual break redux reducer
- Break CRUD logic is shifted from schedule reducer to break reducer
- Adds a cap of 10 breaks per user