### PR TITLE
limit search results to avoid search speed/crashing

### DIFF
--- a/frontend/review-nextjs/hooks/autocomplete.ts
+++ b/frontend/review-nextjs/hooks/autocomplete.ts
@@ -47,9 +47,9 @@ export function useAutocomplete(): [
         () =>
             debouncedQuery.trim() && indices
                 ? {
-                      courses: indices.courses.search(debouncedQuery),
-                      departments: indices.depts.search(debouncedQuery),
-                      instructors: indices.instrs.search(debouncedQuery),
+                      courses: indices.courses.search(debouncedQuery, { limit: 25 }),
+                      departments: indices.depts.search(debouncedQuery, { limit: 10 }),
+                      instructors: indices.instrs.search(debouncedQuery, { limit: 25 }),
                   }
                 : null,
         [debouncedQuery]


### PR DESCRIPTION
Fix app crash/freeze issue by limiting search results to either 10 or 25