### PR TITLE
Add an MCP server for Penn Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is the unified home of all [Penn Courses](https://penncourses.org) products
 
 Note that you need the backend to run the frontend.
 
+There is also an [MCP server](https://github.com/pennlabs/penn-courses/blob/master/mcp/README.md) under `mcp/` that exposes the Penn Courses API to LLM clients (such as Claude) for course planning. It talks to the API over HTTP and runs independently of the backend.
+
 ### Using Dev Containers
 
 This repository has a built-in dev container that you can use to develop the project. To use it, you need to have [Docker](https://www.docker.com/products/docker-desktop) and [VSCode](https://code.visualstudio.com/) installed.

--- a/mcp/.claude/skills/penn-course-planning/SKILL.md
+++ b/mcp/.claude/skills/penn-course-planning/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: penn-course-planning
+description: Plan University of Pennsylvania courses using the penn-course MCP server — search the catalog, read Penn Course Review ratings, compare courses, detect schedule time-conflicts, and assemble a weekly schedule. Use whenever the user asks about Penn/UPenn courses, professors, course difficulty/workload/quality, what classes to take, fulfilling a requirement or attribute (Gen-Ed), or building/checking a semester schedule.
+---
+
+# Penn course planning
+
+This skill drives the **`penn-course`** MCP server (tools are named `search_courses`,
+`get_course_details`, etc.). It talks to the public Penn Courses / Penn Course Review API,
+so data is real and current. No auth is required for catalog data and aggregate ratings.
+
+**Detailed reviews are enabled** on this setup: a logged-in Penn session cookie
+(`PENN_COURSES_SESSION_COOKIE`) is configured, so `get_course_reviews` returns full
+per-instructor written reviews — not just aggregates. Call `get_current_semester` to confirm
+(`reviews_enabled: true`). The session cookie expires periodically (logout / Penn timeout);
+when it lapses, `get_course_reviews` silently falls back to public aggregates and reports
+`auth_status: unauthenticated` — that's the cue to refresh the cookie, not a bug.
+
+## Conventions (read first)
+
+- **Course codes**: `SUBJECT-NUMBER`, e.g. `CIS-1200`, `MATH-1400`, `ECON-0100`. Always
+  hyphenated and uppercase. If the user writes "CIS 120" or "cis120", normalize to `CIS-1200`
+  (Penn moved to 4-digit codes; `CIS-120` → `CIS-1200`, `CIS-160` → `CIS-1600`).
+- **Section ids**: course code + 3-digit section, e.g. `CIS-1200-001`.
+- **Semester**: term code like `2026C` (`A`=spring, `B`=summer, `C`=fall). Omit the
+  `semester` argument to use the current term; call `get_current_semester` first if unsure.
+- **Ratings scale**: roughly 0–4. Higher `course_quality` / `instructor_quality` is better;
+  **lower** `difficulty` and `work_required` mean a lighter course. Some courses are unrated
+  (`null`) — say so rather than treating null as 0.
+- **Meeting times** come back already formatted as `HH:MM` ranges with day codes
+  `M T W R F` (**R = Thursday**). Don't re-parse Penn's raw `HH.MM` encoding yourself.
+
+## Tools at a glance
+
+| Goal | Tool |
+| --- | --- |
+| Current term + auth status | `get_current_semester` |
+| Find courses by keyword/code | `search_courses` |
+| Full course info + sections | `get_course_details` |
+| Just the sections/meeting times | `list_course_sections` (filters: `open_only`, `activity`) |
+| Aggregate ratings | `get_course_ratings` |
+| Detailed PCR reviews | `get_course_reviews` (falls back to aggregates if unauthenticated) |
+| Courses with an attribute / Gen-Ed | `find_courses_by_attribute` |
+| Courses fulfilling a requirement | `find_courses_by_requirement` |
+| Do these sections clash? | `check_schedule_conflicts` |
+| Build a weekly schedule | `build_schedule` |
+| Rank by quality/difficulty/workload | `recommend_courses` (`sort_by=...`) |
+| Side-by-side comparison | `compare_courses` |
+| List your saved PCP schedules | `list_schedules` (requires auth) |
+| **Save a schedule to penncourseplan.com** | `save_schedule` (requires auth — **writes to your account**) |
+| Delete a saved schedule | `delete_schedule` (requires auth) |
+
+## Workflows
+
+**"Tell me about CIS 1200 / is it hard / who teaches it?"**
+→ `get_course_details` (description, prereqs, attributes, sections) +
+`get_course_ratings`. For per-instructor depth use `get_course_reviews` — with the configured
+session cookie this returns full written breakdowns per instructor; if the cookie has expired
+it returns aggregates plus an `unauthenticated` note (expected, not an error).
+
+**"What's a good / easy class about <topic>?"**
+→ `recommend_courses` with the topic as `query`. Use `sort_by="course_quality"` for "good",
+`sort_by="difficulty"` or `"work_required"` for "easy/light". Present the top few with their
+ratings, and flag unrated ones.
+
+**"Compare CIS 1200 vs CIS 1600."**
+→ `compare_courses` with both codes. Summarize the quality/difficulty/workload deltas and
+note prereq differences.
+
+**"Does this schedule work / do these classes conflict?"**
+→ Resolve each course to a concrete **section id** first (use `list_course_sections` to pick
+sections, ideally `open_only=true`). Then `check_schedule_conflicts` for a quick yes/no, or
+`build_schedule` for the full weekly grid + total credits + missing-companion warnings
+(e.g. a LEC that needs a REC/LAB). Report any `not_found` section ids back to the user.
+
+**"What fulfills <requirement / Gen-Ed attribute>?"**
+→ `find_courses_by_attribute` when you have an attribute code (use `match="description"` to
+search by words; add `prefilter_query` to narrow a big catalog and keep it fast), or
+`find_courses_by_requirement` for a requirement name/code.
+
+**"Save / push this schedule to Penn Course Plan so I can see it on the site."**
+→ `save_schedule(name, sections=[...])` writes a new schedule to the user's **live**
+penncourseplan.com account; it appears after they refresh and pick it from the schedule
+dropdown. This is a **real mutation on their account** — confirm the course list and the name
+first, and default to creating a *new* schedule rather than overwriting one. Pass
+`schedule_id` only to deliberately overwrite an existing schedule (find ids via
+`list_schedules`). Use `delete_schedule` to remove one. All three need the session cookie
+(`reviews_enabled: true` is a good proxy that auth is configured); without it they return a
+clear `WriteAuthRequired` error, never a crash.
+
+## Good habits
+
+- Lead with `get_current_semester` when the term matters or the user didn't specify one.
+- When a course or section isn't found, double-check the code format before telling the user
+  it doesn't exist — most "not found" results are a `CIS 120` vs `CIS-1200` normalization miss.
+- Quote real numbers from the tools (quality 2.8, difficulty 3.0…) and cite the section/day/time
+  rather than paraphrasing vaguely. Distinguish "lightly rated / no reviews" from "low rating".
+- The data is a snapshot of the live catalog; sections fill up, so treat `status`/capacity as
+  point-in-time.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,160 @@
+# penn-course-mcp
+
+An [MCP](https://modelcontextprotocol.io) server for University of Pennsylvania course
+planning. It is built on the public [Penn Courses](https://github.com/pennlabs/penn-courses)
+API (the same backend behind Penn Course Plan and Penn Course Review), so the catalog,
+ratings, and schedule data are live.
+
+With it, an MCP client (Claude Desktop, Claude Code, or any other) can search the course
+catalog, inspect sections and meeting times, read ratings and reviews, check a set of
+sections for time conflicts, assemble a weekly schedule, and save that schedule back to a
+Penn Course Plan account.
+
+The server works with no configuration against the public API. Setting a session cookie
+additionally unlocks detailed Penn Course Review breakdowns and the schedule-write tools. It
+runs over stdio for local clients, or streamable HTTP when hosted.
+
+> This package lives in the Penn Courses monorepo under `mcp/`. It talks to the Penn Courses
+> API over HTTP and does not import the Django backend, so it can be developed and run on its
+> own. All commands below are run from the `mcp/` directory.
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `get_current_semester` | Active term code (e.g. `2026C`) and review-auth status |
+| `search_courses` | Search the catalog by code or keyword; returns summaries and ratings |
+| `get_course_details` | Full course info: description, prereqs, attributes, sections, meeting times |
+| `list_course_sections` | Sections with formatted meeting times and instructors; filter by status or activity |
+| `get_course_ratings` | Public aggregate ratings (quality, difficulty, workload) |
+| `get_course_reviews` | Detailed PCR reviews when authenticated; falls back to aggregates otherwise |
+| `find_courses_by_attribute` | Courses carrying a given attribute or Gen-Ed code |
+| `find_courses_by_requirement` | Courses fulfilling a requirement (by code or name) |
+| `check_schedule_conflicts` | Detect time conflicts among a set of section ids |
+| `build_schedule` | Weekly grid, total credits, conflicts, and missing-companion warnings |
+| `compare_courses` | Side-by-side ratings, difficulty, workload, and prereqs |
+| `recommend_courses` | Search and rank by quality, difficulty, or workload |
+| `list_schedules` | List the saved schedules in your Penn Course Plan account (auth) |
+| `save_schedule` | Write a schedule to your Penn Course Plan account so it shows on the site (auth) |
+| `delete_schedule` | Delete a saved Penn Course Plan schedule by id (auth) |
+
+Course codes look like `CIS-1200`; section ids look like `CIS-1200-001`.
+
+## Installation
+
+```bash
+cd mcp
+uv pip install -e ".[dev]"   # or: pip install -e ".[dev]"
+```
+
+## Running
+
+```bash
+# stdio (default), for Claude Desktop / Claude Code
+penn-course-mcp
+
+# streamable HTTP at http://127.0.0.1:8000/mcp
+penn-course-mcp --transport http --port 8000
+
+# development server / MCP Inspector
+fastmcp dev src/penn_course_mcp/server.py
+```
+
+### Client configuration
+
+Add the server to your MCP client config (for Claude Desktop, this is
+`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "penn-course": {
+      "command": "uvx",
+      "args": ["penn-course-mcp"],
+      "env": {
+        "PENN_COURSES_SESSION_COOKIE": ""
+      }
+    }
+  }
+}
+```
+
+> Use `"command": "penn-course-mcp"` instead of `uvx` if you installed the package into a
+> virtualenv that is on your `PATH`.
+
+## Configuration
+
+All environment variables are optional (see [`.env.example`](.env.example)):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PENN_COURSES_BASE_URL` | `https://penncoursereview.com` | API base URL |
+| `PENN_COURSES_SEMESTER` | `current` | Default semester (`current` auto-resolves) |
+| `PENN_COURSES_CACHE_TTL` | `3600` | Cache TTL (seconds) for catalog and detail data |
+| `PENN_COURSES_TIMEOUT` | `20.0` | HTTP timeout (seconds) |
+| `PENN_COURSES_USER_AGENT` | `penn-course-mcp/<ver>` | Sent with every request |
+| `PENN_COURSES_SESSION_COOKIE` | _(unset)_ | Enables detailed reviews and schedule writes (see below) |
+| `PENN_COURSES_TRANSPORT` / `--transport` | `stdio` | `stdio` or `http` |
+| `PENN_COURSES_HOST` / `--host` | `127.0.0.1` | HTTP host |
+| `PENN_COURSES_PORT` / `--port` | `8000` | HTTP port |
+
+### Detailed reviews and schedule writes
+
+The public API exposes aggregate ratings (course and instructor quality, difficulty, and work
+required) without authentication. The detailed per-instructor Penn Course Review breakdowns,
+and the schedule-write tools, require a logged-in Penn session. To enable them, log in to
+penncoursereview.com, copy your session cookie, and set:
+
+```bash
+export PENN_COURSES_SESSION_COOKIE="sessionid=...; csrftoken=..."
+```
+
+`get_course_reviews` falls back to the public aggregate ratings when no cookie is set, so it
+never errors. The schedule-write tools (`list_schedules`, `save_schedule`, `delete_schedule`)
+read and modify a real Penn Course Plan account, so they always need the cookie. Writes also
+need the `csrftoken` value, since Django enforces CSRF on unsafe methods. `save_schedule`
+creates a new schedule by default; pass an existing `schedule_id` (from `list_schedules`) to
+overwrite one instead.
+
+> The read-only catalog and rating tools never modify your account. Only the three schedule
+> tools do.
+
+## Claude skill
+
+This repository ships an optional [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills)
+at [`.claude/skills/penn-course-planning`](.claude/skills/penn-course-planning/SKILL.md). It
+gives Claude guidance on using the tools well, including normalizing course codes (`CIS 120`
+to `CIS-1200`), reading the rating scales, and choosing the right tool for schedule and
+requirement questions. It activates automatically when you use Claude Code in this repository.
+To make it available everywhere, copy it into your user skills folder:
+
+```bash
+cp -R .claude/skills/penn-course-planning ~/.claude/skills/
+```
+
+## Development
+
+```bash
+uv pip install -e ".[dev]"
+pytest      # pure planning logic, mocked client, and tool tests
+flake8      # style, import order (isort), and quote checks
+black .     # formatter
+```
+
+The planning logic in `src/penn_course_mcp/planning.py` is pure and network-free, so the
+schedule-conflict detection, time formatting, and comparison are covered by unit tests
+without hitting the API.
+
+## Notes
+
+- Meeting times use Penn's `HH.MM` encoding (`10.15` is 10:15, `15.3` is 15:30). The server
+  renders them as readable `HH:MM` ranges.
+- Day codes are `M`, `T`, `W`, `R`, `F`, where `R` is Thursday.
+- Back-to-back meetings, where one ends exactly as the next begins, are not counted as
+  conflicts.
+- This is an unofficial tool that consumes the public Penn Courses API. It caches responses
+  and caps concurrency; please use it respectfully.
+
+## License
+
+MIT

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "penn-course-mcp"
+version = "0.1.0"
+description = "An MCP server for Penn course planning, built on the open-source Penn Courses (Penn Course Plan / Review) public API."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Grant DeHoog" }]
+keywords = ["mcp", "penn", "courses", "upenn", "course-planning", "llm"]
+dependencies = [
+    "fastmcp>=2.0",
+    "httpx>=0.27",
+    "pydantic>=2",
+    "cachetools>=5",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black==22.3.0",
+    "flake8==7.1.1",
+    "flake8-isort==6.1.1",
+    "flake8-quotes==3.4.0",
+    "isort==5.13.2",
+    "pytest==8.3.3",
+    "pytest-asyncio>=0.23",
+    "respx>=0.21",
+]
+
+[project.scripts]
+penn-course-mcp = "penn_course_mcp.server:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/penn_course_mcp"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.black]
+line-length = 100

--- a/mcp/setup.cfg
+++ b/mcp/setup.cfg
@@ -1,0 +1,14 @@
+[flake8]
+max-line-length = 100
+exclude = .venv, build, dist
+inline-quotes = double
+ignore = E231 W503
+
+[isort]
+default_section = THIRDPARTY
+known_first_party = penn_course_mcp
+line_length = 100
+lines_after_imports = 2
+multi_line_output = 3
+include_trailing_comma = True
+use_parentheses = True

--- a/mcp/src/penn_course_mcp/__init__.py
+++ b/mcp/src/penn_course_mcp/__init__.py
@@ -1,0 +1,6 @@
+"""penn-course-mcp: an MCP server for Penn course planning.
+
+Built on the open-source Penn Courses (Penn Course Plan / Review) public API.
+"""
+
+__version__ = "0.1.0"

--- a/mcp/src/penn_course_mcp/client.py
+++ b/mcp/src/penn_course_mcp/client.py
@@ -1,0 +1,248 @@
+"""Async HTTP client for the Penn Courses public API.
+
+Wraps the handful of upstream endpoints with caching, semester resolution,
+politeness controls, and translation of HTTP errors into domain exceptions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any
+
+import httpx
+from cachetools import TTLCache
+
+from .config import Settings
+from .errors import CourseNotFound, ReviewAuthRequired, UpstreamError, WriteAuthRequired
+
+
+# Search results change a bit more often than catalog/detail data, so cache them
+# for a shorter window.
+SEARCH_CACHE_TTL = 300
+MAX_CONCURRENCY = 5
+
+
+class PennCoursesClient:
+    """Thin async wrapper over the Penn Courses REST API."""
+
+    def __init__(self, settings: Settings | None = None):
+        self.settings = settings or Settings.from_env()
+        self._client: httpx.AsyncClient | None = None
+        self._sem = asyncio.Semaphore(MAX_CONCURRENCY)
+        # Long-lived cache for stable endpoints (catalog, course detail, options).
+        self._cache: TTLCache = TTLCache(maxsize=2048, ttl=self.settings.cache_ttl)
+        # Short-lived cache for searches.
+        self._search_cache: TTLCache = TTLCache(maxsize=512, ttl=SEARCH_CACHE_TTL)
+        self._resolved_semester: str | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+    @property
+    def client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.settings.base_url,
+                headers={
+                    "User-Agent": self.settings.user_agent,
+                    "Accept": "application/json",
+                },
+                timeout=self.settings.timeout,
+            )
+        return self._client
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # -- low-level GET -----------------------------------------------------
+    async def _get_json(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        cache: TTLCache | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        cache_key = path + ("?" + httpx.QueryParams(params).__str__() if params else "")
+        store = cache if cache is not None else self._cache
+        if cache_key in store:
+            return store[cache_key]
+
+        async with self._sem:
+            data = await self._request_with_retry(path, params=params, headers=headers)
+        store[cache_key] = data
+        return data
+
+    async def _request_with_retry(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None,
+        headers: dict[str, str] | None,
+    ) -> Any:
+        last_exc: Exception | None = None
+        for attempt in range(2):  # one retry on transient failures
+            try:
+                resp = await self.client.get(path, params=params, headers=headers)
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                last_exc = exc
+                if attempt == 0:
+                    await asyncio.sleep(0.5)
+                    continue
+                raise UpstreamError(f"Request to {path} failed: {exc}") from exc
+
+            if resp.status_code == 404:
+                raise CourseNotFound(path)
+            if resp.status_code in (401, 403):
+                raise UpstreamError(
+                    f"Access denied ({resp.status_code}) for {path}.",
+                    status=resp.status_code,
+                )
+            if resp.status_code >= 500:
+                last_exc = UpstreamError(
+                    f"Upstream error {resp.status_code} for {path}.",
+                    status=resp.status_code,
+                )
+                if attempt == 0:
+                    await asyncio.sleep(0.5)
+                    continue
+                raise last_exc
+            try:
+                return resp.json()
+            except ValueError as exc:
+                raise UpstreamError(f"Invalid JSON from {path}: {exc}") from exc
+        # unreachable, but satisfies type checkers
+        raise UpstreamError(f"Request to {path} failed: {last_exc}")
+
+    # -- endpoints ---------------------------------------------------------
+    async def get_options(self) -> dict[str, Any]:
+        return await self._get_json("/api/options/")
+
+    async def resolve_semester(self, semester: str | None) -> str:
+        """Resolve ``None``/``"current"`` to a concrete semester code (e.g. 2026C)."""
+        candidate = semester or self.settings.semester
+        if candidate and candidate.lower() != "current":
+            return candidate
+        if self._resolved_semester is None:
+            options = await self.get_options()
+            self._resolved_semester = options.get("SEMESTER", "current")
+        return self._resolved_semester
+
+    async def search_courses(self, semester: str | None, query: str) -> list[dict[str, Any]]:
+        sem = await self.resolve_semester(semester)
+        return await self._get_json(
+            f"/api/base/{sem}/search/courses/",
+            params={"search": query},
+            cache=self._search_cache,
+        )
+
+    async def list_all_courses(self, semester: str | None) -> list[dict[str, Any]]:
+        sem = await self.resolve_semester(semester)
+        return await self._get_json(f"/api/base/{sem}/courses/")
+
+    async def get_course(self, semester: str | None, code: str) -> dict[str, Any]:
+        sem = await self.resolve_semester(semester)
+        code = code.upper()
+        try:
+            return await self._get_json(f"/api/base/{sem}/courses/{code}/")
+        except CourseNotFound as exc:
+            raise CourseNotFound(code, sem) from exc
+
+    # -- authenticated writes (Penn Course Plan schedules) -----------------
+    def _csrf_token(self) -> str | None:
+        """Pull the csrftoken out of the configured session cookie, if present."""
+        match = re.search(r"csrftoken=([^;]+)", self.settings.session_cookie or "")
+        return match.group(1) if match else None
+
+    async def _authed_request(self, method: str, path: str, *, json_body: Any | None = None) -> Any:
+        """Make an authenticated request (used for the Plan schedule endpoints).
+
+        Unsafe methods carry the CSRF token plus matching Referer/Origin so Django's
+        SessionAuthentication accepts them. Never cached.
+        """
+        if not self.settings.session_cookie:
+            raise WriteAuthRequired()
+        headers = {
+            "Cookie": self.settings.session_cookie,
+            "Accept": "application/json",
+            "Referer": self.settings.base_url + "/",
+            "Origin": self.settings.base_url,
+        }
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+        token = self._csrf_token()
+        if token:
+            headers["X-CSRFToken"] = token
+
+        async with self._sem:
+            try:
+                resp = await self.client.request(method, path, json=json_body, headers=headers)
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                raise UpstreamError(f"{method} {path} failed: {exc}") from exc
+
+        if resp.status_code in (401, 403):
+            raise WriteAuthRequired()
+        if resp.status_code == 404:
+            raise CourseNotFound(path)
+        if resp.status_code >= 400:
+            raise UpstreamError(
+                f"{method} {path} failed ({resp.status_code}): {resp.text[:200]}",
+                status=resp.status_code,
+            )
+        if resp.status_code == 204 or not resp.content:
+            return {}
+        try:
+            return resp.json()
+        except ValueError:
+            return {"raw": resp.text}
+
+    async def list_schedules(self) -> list[dict[str, Any]]:
+        """Return the authenticated user's saved Penn Course Plan schedules."""
+        return await self._authed_request("GET", "/api/plan/schedules/")
+
+    async def save_schedule(
+        self,
+        *,
+        name: str,
+        semester: str | None,
+        section_ids: list[str],
+        schedule_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Create (or update, if ``schedule_id`` is given) a Plan schedule.
+
+        ``section_ids`` are full section codes like 'CIS-1200-001'.
+        """
+        if not self.settings.session_cookie:
+            raise WriteAuthRequired()
+        sem = await self.resolve_semester(semester)
+        payload: dict[str, Any] = {
+            "semester": sem,
+            "name": name,
+            "sections": [{"id": s.upper(), "semester": sem} for s in section_ids],
+        }
+        if schedule_id is not None:
+            payload["id"] = schedule_id
+            return await self._authed_request(
+                "PUT", f"/api/plan/schedules/{schedule_id}/", json_body=payload
+            )
+        return await self._authed_request("POST", "/api/plan/schedules/", json_body=payload)
+
+    async def delete_schedule(self, schedule_id: int) -> None:
+        """Delete a saved schedule by id."""
+        await self._authed_request("DELETE", f"/api/plan/schedules/{schedule_id}/")
+
+    async def get_review(self, code: str) -> dict[str, Any]:
+        """Fetch detailed reviews. Requires an authenticated session cookie."""
+        code = code.upper()
+        if not self.settings.session_cookie:
+            raise ReviewAuthRequired(code)
+        headers = {"Cookie": self.settings.session_cookie}
+        try:
+            return await self._get_json(f"/api/review/course/{code}", headers=headers)
+        except UpstreamError as exc:
+            if exc.status in (401, 403):
+                raise ReviewAuthRequired(code) from exc
+            raise
+        except CourseNotFound as exc:
+            raise CourseNotFound(code) from exc

--- a/mcp/src/penn_course_mcp/config.py
+++ b/mcp/src/penn_course_mcp/config.py
@@ -1,0 +1,65 @@
+"""Runtime configuration, sourced from environment variables.
+
+Everything is optional: with zero configuration the server talks to the public
+Penn Courses API. Setting ``PENN_COURSES_SESSION_COOKIE`` additionally unlocks
+the authenticated review endpoints.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from . import __version__
+
+
+DEFAULT_BASE_URL = "https://penncoursereview.com"
+DEFAULT_SEMESTER = "current"
+DEFAULT_CACHE_TTL = 3600
+DEFAULT_TIMEOUT = 20.0
+
+
+def _get_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _get_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class Settings:
+    base_url: str = DEFAULT_BASE_URL
+    semester: str = DEFAULT_SEMESTER
+    cache_ttl: int = DEFAULT_CACHE_TTL
+    timeout: float = DEFAULT_TIMEOUT
+    user_agent: str = f"penn-course-mcp/{__version__}"
+    session_cookie: str | None = None
+
+    @property
+    def reviews_enabled(self) -> bool:
+        return bool(self.session_cookie)
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        cookie = os.environ.get("PENN_COURSES_SESSION_COOKIE") or None
+        return cls(
+            base_url=os.environ.get("PENN_COURSES_BASE_URL", DEFAULT_BASE_URL).rstrip("/"),
+            semester=os.environ.get("PENN_COURSES_SEMESTER", DEFAULT_SEMESTER),
+            cache_ttl=_get_int("PENN_COURSES_CACHE_TTL", DEFAULT_CACHE_TTL),
+            timeout=_get_float("PENN_COURSES_TIMEOUT", DEFAULT_TIMEOUT),
+            user_agent=os.environ.get("PENN_COURSES_USER_AGENT", f"penn-course-mcp/{__version__}"),
+            session_cookie=cookie,
+        )

--- a/mcp/src/penn_course_mcp/errors.py
+++ b/mcp/src/penn_course_mcp/errors.py
@@ -1,0 +1,51 @@
+"""Domain exceptions raised by the Penn Courses client.
+
+Tools catch these and translate them into friendly, structured results so the
+calling model receives actionable text instead of a stack trace.
+"""
+
+from __future__ import annotations
+
+
+class PennCoursesError(Exception):
+    """Base class for all penn-course-mcp errors."""
+
+
+class CourseNotFound(PennCoursesError):
+    """A requested course (or section) does not exist for the given semester."""
+
+    def __init__(self, code: str, semester: str | None = None):
+        self.code = code
+        self.semester = semester
+        suffix = f" in {semester}" if semester else ""
+        super().__init__(f"Course '{code}' was not found{suffix}.")
+
+
+class ReviewAuthRequired(PennCoursesError):
+    """The detailed review endpoint requires an authenticated Penn session."""
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(
+            f"Detailed reviews for '{code}' require authentication. "
+            "Set PENN_COURSES_SESSION_COOKIE to enable them."
+        )
+
+
+class WriteAuthRequired(PennCoursesError):
+    """A write (schedule save/delete) needs an authenticated Penn session."""
+
+    def __init__(self, action: str = "modify schedules"):
+        self.action = action
+        super().__init__(
+            f"Authentication is required to {action}. Set PENN_COURSES_SESSION_COOKIE "
+            "to a logged-in Penn session cookie that includes both sessionid and csrftoken."
+        )
+
+
+class UpstreamError(PennCoursesError):
+    """The upstream API returned an unexpected error or was unreachable."""
+
+    def __init__(self, message: str, status: int | None = None):
+        self.status = status
+        super().__init__(message)

--- a/mcp/src/penn_course_mcp/planning.py
+++ b/mcp/src/penn_course_mcp/planning.py
@@ -1,0 +1,225 @@
+"""Pure, network-free course-planning logic.
+
+Everything here operates on plain dicts (the shapes returned by the Penn Courses
+API) and primitives, so it is trivially unit-testable without mocking HTTP.
+
+Conventions from the upstream API:
+- Meeting times use Penn's ``HH.MM`` float encoding: the integer part is the
+  24-hour hour and the two decimal digits are literal minutes. So ``10.15`` ->
+  10:15, ``15.3`` -> 15:30, ``12.59`` -> 12:59. (This ordering is chronological,
+  so raw float comparison is safe for overlap detection.)
+- Day codes are single letters: M, T, W, R (Thursday), F, and occasionally
+  S (Saturday) / U (Sunday).
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any, Iterable
+
+
+DAY_NAMES: dict[str, str] = {
+    "M": "Monday",
+    "T": "Tuesday",
+    "W": "Wednesday",
+    "R": "Thursday",
+    "F": "Friday",
+    "S": "Saturday",
+    "U": "Sunday",
+}
+DAY_ORDER = ["M", "T", "W", "R", "F", "S", "U"]
+
+
+def fmt_time(value: float | int | None) -> str:
+    """Format Penn's ``HH.MM`` float time as a 24h ``HH:MM`` string.
+
+    The two decimal digits are literal minutes: ``10.15`` -> ``"10:15"``,
+    ``15.3`` -> ``"15:30"``, ``12.0`` -> ``"12:00"``. Returns ``"TBA"`` for
+    missing values.
+    """
+    if value is None:
+        return "TBA"
+    hours = int(value)
+    minutes = round((float(value) - hours) * 100)
+    return f"{hours:02d}:{minutes:02d}"
+
+
+def fmt_meeting(meeting: dict[str, Any]) -> str:
+    """Render a single meeting dict as e.g. ``"Monday 10:00-11:30 (Towne 100)"``."""
+    day = DAY_NAMES.get(meeting.get("day", ""), meeting.get("day", "?"))
+    start = fmt_time(meeting.get("start"))
+    end = fmt_time(meeting.get("end"))
+    room = meeting.get("room")
+    base = f"{day} {start}-{end}"
+    return f"{base} ({room})" if room else base
+
+
+def meetings_overlap(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """True if two meetings fall on the same day with overlapping time ranges.
+
+    Uses strict inequality so that back-to-back meetings (one ending exactly when
+    the next begins) are *not* treated as a conflict.
+    """
+    if a.get("day") != b.get("day"):
+        return False
+    a_start, a_end = a.get("start"), a.get("end")
+    b_start, b_end = b.get("start"), b.get("end")
+    if None in (a_start, a_end, b_start, b_end):
+        return False  # cannot judge a TBA meeting
+    return a_start < b_end and b_start < a_end
+
+
+def _section_meetings(section: dict[str, Any]) -> list[dict[str, Any]]:
+    return section.get("meetings") or []
+
+
+def detect_conflicts(sections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Find all pairwise time conflicts among a candidate set of sections.
+
+    Each ``section`` dict must contain ``id`` (or ``section_id``) and ``meetings``.
+    Returns a list of conflict records describing the two clashing meetings.
+    """
+    conflicts: list[dict[str, Any]] = []
+    for sec_a, sec_b in combinations(sections, 2):
+        id_a = sec_a.get("id") or sec_a.get("section_id", "?")
+        id_b = sec_b.get("id") or sec_b.get("section_id", "?")
+        for m_a in _section_meetings(sec_a):
+            for m_b in _section_meetings(sec_b):
+                if meetings_overlap(m_a, m_b):
+                    conflicts.append(
+                        {
+                            "section_a": id_a,
+                            "section_b": id_b,
+                            "day": DAY_NAMES.get(m_a.get("day", ""), m_a.get("day")),
+                            "meeting_a": fmt_meeting(m_a),
+                            "meeting_b": fmt_meeting(m_b),
+                        }
+                    )
+    return conflicts
+
+
+def weekly_grid(sections: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Group section meetings into a day-keyed, time-sorted weekly grid."""
+    grid: dict[str, list[dict[str, Any]]] = {DAY_NAMES[d]: [] for d in DAY_ORDER}
+    for section in sections:
+        sec_id = section.get("id") or section.get("section_id", "?")
+        for m in _section_meetings(section):
+            day = DAY_NAMES.get(m.get("day", ""))
+            if day is None:
+                continue
+            grid[day].append(
+                {
+                    "section": sec_id,
+                    "start": fmt_time(m.get("start")),
+                    "end": fmt_time(m.get("end")),
+                    "room": m.get("room"),
+                    "_sort": m.get("start") if m.get("start") is not None else 99,
+                }
+            )
+    for day in grid:
+        grid[day].sort(key=lambda x: x["_sort"])
+        for entry in grid[day]:
+            entry.pop("_sort", None)
+    # drop empty days for a tidier result
+    return {day: entries for day, entries in grid.items() if entries}
+
+
+def missing_associated_warnings(
+    sections: list[dict[str, Any]],
+) -> list[str]:
+    """Warn when a section lists required ``associated_sections`` that are absent.
+
+    Many Penn lectures require a co-registered recitation/lab; the API exposes
+    these via ``associated_sections``. We flag a lecture whose companions are not
+    present in the chosen set.
+    """
+    chosen_ids = {s.get("id") or s.get("section_id") for s in sections}
+    warnings: list[str] = []
+    for section in sections:
+        sec_id = section.get("id") or section.get("section_id", "?")
+        associated = section.get("associated_sections") or []
+        present = [a for a in associated if a.get("id") in chosen_ids]
+        if associated and not present:
+            options = ", ".join(f"{a.get('id')} ({a.get('activity')})" for a in associated)
+            warnings.append(
+                f"{sec_id} typically requires a companion section; none selected. "
+                f"Options: {options}"
+            )
+    return warnings
+
+
+def build_schedule(sections: list[dict[str, Any]]) -> dict[str, Any]:
+    """Assemble a weekly schedule summary from a set of section dicts.
+
+    Returns total credits, the weekly grid, time conflicts, and warnings for
+    missing required companion sections.
+    """
+    total_credits = 0.0
+    for s in sections:
+        try:
+            total_credits += float(s.get("credits") or 0)
+        except (TypeError, ValueError):
+            pass
+    conflicts = detect_conflicts(sections)
+    return {
+        "sections": [s.get("id") or s.get("section_id") for s in sections],
+        "total_credits": round(total_credits, 2),
+        "weekly_grid": weekly_grid(sections),
+        "conflicts": conflicts,
+        "has_conflicts": bool(conflicts),
+        "warnings": missing_associated_warnings(sections),
+    }
+
+
+def compare_courses(details: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a side-by-side comparison table from full course-detail dicts."""
+    fields = [
+        "title",
+        "credits",
+        "course_quality",
+        "instructor_quality",
+        "difficulty",
+        "work_required",
+        "num_sections",
+        "prerequisites",
+    ]
+    rows: list[dict[str, Any]] = []
+    for d in details:
+        row = {"course": d.get("id")}
+        for f in fields:
+            if f == "num_sections":
+                row[f] = d.get("num_sections") or len(d.get("sections") or [])
+            else:
+                row[f] = d.get(f)
+        rows.append(row)
+    return {"courses": [d.get("id") for d in details], "comparison": rows}
+
+
+def _course_matches(course: dict[str, Any], target: str, match: str) -> bool:
+    target_l = target.lower()
+    attributes = course.get("attributes") or []
+    pre_ngss = course.get("pre_ngss_requirements") or []
+    haystacks: list[str] = []
+    for attr in attributes:
+        if match == "code":
+            haystacks.append(str(attr.get("code", "")))
+        else:  # "description"
+            haystacks.append(str(attr.get("description", "")))
+            haystacks.append(str(attr.get("code", "")))
+    for req in pre_ngss:
+        haystacks.append(str(req.get("code", "")))
+        haystacks.append(str(req.get("name", "")))
+    if match == "code":
+        return any(target_l == h.lower() for h in haystacks)
+    return any(target_l in h.lower() for h in haystacks)
+
+
+def filter_courses_by_attribute(
+    courses: Iterable[dict[str, Any]], target: str, match: str = "code"
+) -> list[dict[str, Any]]:
+    """Client-side filter over course ``attributes`` / ``pre_ngss_requirements``.
+
+    ``match="code"`` requires an exact attribute-code match; ``match="description"``
+    does a case-insensitive substring search across codes and descriptions.
+    """
+    return [c for c in courses if _course_matches(c, target, match)]

--- a/mcp/src/penn_course_mcp/server.py
+++ b/mcp/src/penn_course_mcp/server.py
@@ -1,0 +1,572 @@
+"""FastMCP server exposing Penn course-planning tools.
+
+Run with stdio (default) or streamable HTTP:
+
+    penn-course-mcp                       # stdio
+    penn-course-mcp --transport http      # HTTP at http://127.0.0.1:8000/mcp
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from . import __version__
+from .client import PennCoursesClient
+from .config import Settings
+from .errors import (
+    CourseNotFound,
+    PennCoursesError,
+    ReviewAuthRequired,
+    UpstreamError,
+    WriteAuthRequired,
+)
+from .planning import build_schedule as _build_schedule
+from .planning import compare_courses as _compare_courses
+from .planning import detect_conflicts as _detect_conflicts
+from .planning import filter_courses_by_attribute, fmt_meeting
+
+
+mcp = FastMCP(
+    name="penn-course-mcp",
+    instructions=(
+        "Tools for planning courses at the University of Pennsylvania using the "
+        "public Penn Courses (Penn Course Plan / Review) API. Use search_courses to "
+        "discover courses, get_course_details for full info, and the schedule tools "
+        "to detect time conflicts and assemble a weekly plan. Course codes look like "
+        "'CIS-1200'; section ids look like 'CIS-1200-001'. Ratings range roughly 0-4 "
+        "(higher course_quality/instructor_quality is better; lower difficulty and "
+        "work_required is lighter)."
+    ),
+)
+
+_client: PennCoursesClient | None = None
+
+
+def get_client() -> PennCoursesClient:
+    global _client
+    if _client is None:
+        _client = PennCoursesClient(Settings.from_env())
+    return _client
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+def _err(exc: Exception) -> dict[str, Any]:
+    """Translate an exception into a friendly, structured tool result."""
+    if isinstance(exc, CourseNotFound):
+        return {
+            "error": str(exc),
+            "hint": "Check the course code (e.g. 'CIS-1200') and semester.",
+        }
+    if isinstance(exc, ReviewAuthRequired):
+        return {
+            "error": str(exc),
+            "hint": "Set PENN_COURSES_SESSION_COOKIE to enable detailed reviews.",
+        }
+    if isinstance(exc, WriteAuthRequired):
+        return {
+            "error": str(exc),
+            "hint": (
+                "Saving schedules requires a logged-in Penn session. Set "
+                "PENN_COURSES_SESSION_COOKIE to include both sessionid and csrftoken."
+            ),
+        }
+    if isinstance(exc, (UpstreamError, PennCoursesError)):
+        return {"error": str(exc), "hint": "The Penn Courses API may be unavailable."}
+    return {"error": f"Unexpected error: {exc}"}
+
+
+def _section_to_course_code(section_id: str) -> str:
+    """'CIS-1200-001' -> 'CIS-1200'."""
+    return section_id.rsplit("-", 1)[0].upper()
+
+
+def _summarize_section(section: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": section.get("id"),
+        "activity": section.get("activity"),
+        "status": section.get("status"),
+        "credits": section.get("credits"),
+        "capacity": section.get("capacity"),
+        "registration_volume": section.get("registration_volume"),
+        "instructors": [i.get("name") for i in section.get("instructors") or []],
+        "meetings": [fmt_meeting(m) for m in section.get("meetings") or []],
+        "associated_sections": [
+            {"id": a.get("id"), "activity": a.get("activity")}
+            for a in section.get("associated_sections") or []
+        ],
+    }
+
+
+async def _resolve_section_dicts(
+    semester: str | None, section_ids: list[str]
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Fetch the section dicts named by ``section_ids`` from their parent courses.
+
+    Returns (found_sections, not_found_ids).
+    """
+    client = get_client()
+    wanted = {sid.upper() for sid in section_ids}
+    by_course: dict[str, list[str]] = {}
+    for sid in wanted:
+        by_course.setdefault(_section_to_course_code(sid), []).append(sid)
+
+    found: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for course_code in by_course:
+        try:
+            course = await client.get_course(semester, course_code)
+        except CourseNotFound:
+            continue
+        for section in course.get("sections") or []:
+            sid = str(section.get("id", "")).upper()
+            if sid in wanted and sid not in seen:
+                # carry credits down from the course if the section omits them
+                section = {**section}
+                section.setdefault("credits", course.get("credits"))
+                found.append(section)
+                seen.add(sid)
+    not_found = sorted(wanted - seen)
+    return found, not_found
+
+
+# --------------------------------------------------------------------------
+# tools — discovery & detail
+# --------------------------------------------------------------------------
+@mcp.tool
+async def get_current_semester() -> dict[str, Any]:
+    """Return the active semester and whether detailed reviews are enabled.
+
+    Useful as a first call to learn the current term code (e.g. '2026C') and the
+    server's review-auth status.
+    """
+    client = get_client()
+    try:
+        options = await client.get_options()
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    return {
+        "semester": options.get("SEMESTER"),
+        "registration_open": options.get("REGISTRATION_OPEN"),
+        "reviews_enabled": client.settings.reviews_enabled,
+    }
+
+
+@mcp.tool
+async def search_courses(
+    query: str, semester: str | None = None, limit: int = 25
+) -> dict[str, Any]:
+    """Search the course catalog by code or keyword (e.g. 'CIS-1200' or 'ethics').
+
+    Returns lightweight course summaries including aggregate ratings. ``semester``
+    defaults to the current term.
+    """
+    client = get_client()
+    try:
+        results = await client.search_courses(semester, query)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    return {
+        "count": len(results),
+        "results": results[: max(0, limit)],
+    }
+
+
+@mcp.tool
+async def get_course_details(course_code: str, semester: str | None = None) -> dict[str, Any]:
+    """Get full details for a course: description, prerequisites, attributes,
+    crosslistings, aggregate ratings, and all sections with meeting times.
+    """
+    client = get_client()
+    try:
+        course = await client.get_course(semester, course_code)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    course = {**course}
+    course["sections"] = [_summarize_section(s) for s in course.get("sections") or []]
+    return course
+
+
+@mcp.tool
+async def list_course_sections(
+    course_code: str,
+    semester: str | None = None,
+    open_only: bool = False,
+    activity: str | None = None,
+) -> dict[str, Any]:
+    """List a course's sections with formatted meeting times and instructors.
+
+    ``open_only`` keeps only sections whose status is open; ``activity`` filters by
+    type (e.g. 'LEC', 'REC', 'LAB').
+    """
+    client = get_client()
+    try:
+        course = await client.get_course(semester, course_code)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    sections = course.get("sections") or []
+    if open_only:
+        sections = [s for s in sections if str(s.get("status", "")).upper() == "O"]
+    if activity:
+        sections = [s for s in sections if str(s.get("activity", "")).upper() == activity.upper()]
+    return {
+        "course": course.get("id"),
+        "count": len(sections),
+        "sections": [_summarize_section(s) for s in sections],
+    }
+
+
+# --------------------------------------------------------------------------
+# tools — ratings & reviews
+# --------------------------------------------------------------------------
+@mcp.tool
+async def get_course_ratings(course_code: str, semester: str | None = None) -> dict[str, Any]:
+    """Return the public aggregate ratings for a course (always available).
+
+    Includes course_quality, instructor_quality, difficulty, and work_required.
+    """
+    client = get_client()
+    try:
+        course = await client.get_course(semester, course_code)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    return {
+        "course": course.get("id"),
+        "course_quality": course.get("course_quality"),
+        "instructor_quality": course.get("instructor_quality"),
+        "difficulty": course.get("difficulty"),
+        "work_required": course.get("work_required"),
+        "credits": course.get("credits"),
+    }
+
+
+@mcp.tool
+async def get_course_reviews(course_code: str) -> dict[str, Any]:
+    """Get detailed Penn Course Review breakdowns for a course.
+
+    When an authenticated session cookie is configured this returns the full
+    per-instructor review data. Otherwise it gracefully falls back to the public
+    aggregate ratings and reports an unauthenticated status (never errors).
+    """
+    client = get_client()
+    try:
+        data = await client.get_review(course_code)
+        return {"auth_status": "authenticated", "reviews": data}
+    except ReviewAuthRequired:
+        # graceful degradation to public aggregates
+        try:
+            course = await client.get_course(None, course_code)
+        except Exception as exc:  # noqa: BLE001
+            return _err(exc)
+        return {
+            "auth_status": "unauthenticated",
+            "note": (
+                "Detailed reviews require authentication; returning public aggregate "
+                "ratings instead. Set PENN_COURSES_SESSION_COOKIE to unlock full reviews."
+            ),
+            "course": course.get("id"),
+            "aggregate_ratings": {
+                "course_quality": course.get("course_quality"),
+                "instructor_quality": course.get("instructor_quality"),
+                "difficulty": course.get("difficulty"),
+                "work_required": course.get("work_required"),
+            },
+        }
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+
+
+# --------------------------------------------------------------------------
+# tools — requirement / attribute discovery
+# --------------------------------------------------------------------------
+@mcp.tool
+async def find_courses_by_attribute(
+    attribute: str,
+    semester: str | None = None,
+    match: str = "code",
+    prefilter_query: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Find courses carrying a given attribute (e.g. 'EUMS', 'MFR', a Gen-Ed code).
+
+    ``match='code'`` requires an exact attribute-code match; ``match='description'``
+    does a substring search across codes and descriptions. Supply ``prefilter_query``
+    to narrow the candidate set first (faster, smaller payload).
+    """
+    client = get_client()
+    try:
+        if prefilter_query:
+            candidates = await client.search_courses(semester, prefilter_query)
+            # search results lack attributes; fetch detail for each candidate
+            detailed = []
+            for c in candidates[:200]:
+                try:
+                    detailed.append(await client.get_course(semester, c["id"]))
+                except CourseNotFound:
+                    continue
+            candidates = detailed
+        else:
+            candidates = await client.list_all_courses(semester)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+
+    matched = filter_courses_by_attribute(candidates, attribute, match=match)
+    return {
+        "attribute": attribute,
+        "match": match,
+        "count": len(matched),
+        "results": [
+            {
+                "id": c.get("id"),
+                "title": c.get("title"),
+                "attributes": [a.get("code") for a in c.get("attributes") or []],
+            }
+            for c in matched[: max(0, limit)]
+        ],
+    }
+
+
+@mcp.tool
+async def find_courses_by_requirement(
+    requirement: str, semester: str | None = None, limit: int = 50
+) -> dict[str, Any]:
+    """Find courses fulfilling a requirement (pre-NGSS requirement code or name).
+
+    Substring-matches against course attributes and pre-NGSS requirement codes/names.
+    """
+    client = get_client()
+    try:
+        candidates = await client.list_all_courses(semester)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    matched = filter_courses_by_attribute(candidates, requirement, match="description")
+    return {
+        "requirement": requirement,
+        "count": len(matched),
+        "results": [{"id": c.get("id"), "title": c.get("title")} for c in matched[: max(0, limit)]],
+    }
+
+
+# --------------------------------------------------------------------------
+# tools — planning utilities
+# --------------------------------------------------------------------------
+@mcp.tool
+async def check_schedule_conflicts(
+    sections: list[str], semester: str | None = None
+) -> dict[str, Any]:
+    """Check a set of section ids (e.g. ['CIS-1200-001','MATH-1400-002']) for time
+    conflicts. Returns the clashing meetings in human-readable form.
+    """
+    try:
+        found, not_found = await _resolve_section_dicts(semester, sections)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    conflicts = _detect_conflicts(found)
+    return {
+        "requested": sections,
+        "not_found": not_found,
+        "has_conflicts": bool(conflicts),
+        "conflicts": conflicts,
+    }
+
+
+@mcp.tool
+async def build_schedule(sections: list[str], semester: str | None = None) -> dict[str, Any]:
+    """Assemble a weekly schedule from section ids: total credits, a day-by-day
+    grid, time conflicts, and warnings for missing required companion sections.
+    """
+    try:
+        found, not_found = await _resolve_section_dicts(semester, sections)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    result = _build_schedule(found)
+    result["not_found"] = not_found
+    return result
+
+
+@mcp.tool
+async def compare_courses(course_codes: list[str], semester: str | None = None) -> dict[str, Any]:
+    """Compare courses side by side on ratings, difficulty, workload, credits, and
+    prerequisites. Accepts a list of course codes (e.g. ['CIS-1200','CIS-1600']).
+    """
+    client = get_client()
+    details: list[dict[str, Any]] = []
+    not_found: list[str] = []
+    for code in course_codes:
+        try:
+            details.append(await client.get_course(semester, code))
+        except CourseNotFound:
+            not_found.append(code.upper())
+        except Exception as exc:  # noqa: BLE001
+            return _err(exc)
+    result = _compare_courses(details)
+    result["not_found"] = not_found
+    return result
+
+
+@mcp.tool
+async def recommend_courses(
+    query: str,
+    semester: str | None = None,
+    sort_by: str = "course_quality",
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Search and rank courses by a quality metric.
+
+    ``sort_by`` is one of: 'course_quality', 'instructor_quality',
+    'recommendation_score' (higher is better), or 'difficulty' / 'work_required'
+    (lower is better, for finding lighter courses).
+    """
+    client = get_client()
+    try:
+        results = await client.search_courses(semester, query)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+
+    ascending = sort_by in ("difficulty", "work_required")
+    valid_keys = {
+        "course_quality",
+        "instructor_quality",
+        "recommendation_score",
+        "difficulty",
+        "work_required",
+    }
+    if sort_by not in valid_keys:
+        sort_by = "course_quality"
+
+    def key(c: dict[str, Any]) -> float:
+        val = c.get(sort_by)
+        if val is None:
+            # push unrated courses to the end regardless of direction
+            return float("inf") if ascending else float("-inf")
+        return float(val)
+
+    ranked = sorted(results, key=key, reverse=not ascending)
+    return {
+        "query": query,
+        "sort_by": sort_by,
+        "order": "ascending" if ascending else "descending",
+        "results": ranked[: max(0, limit)],
+    }
+
+
+# --------------------------------------------------------------------------
+# tools — Penn Course Plan schedule writes (authenticated)
+# --------------------------------------------------------------------------
+@mcp.tool
+async def list_schedules() -> dict[str, Any]:
+    """List the saved schedules in your Penn Course Plan account (requires auth).
+
+    Returns each schedule's id, name, semester, and the section ids it contains —
+    handy for finding a ``schedule_id`` to update or delete.
+    """
+    client = get_client()
+    try:
+        schedules = await client.list_schedules()
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    return {
+        "count": len(schedules),
+        "schedules": [
+            {
+                "id": s.get("id"),
+                "name": s.get("name"),
+                "semester": s.get("semester"),
+                "sections": [sec.get("id") for sec in s.get("sections") or []],
+            }
+            for s in schedules
+        ],
+    }
+
+
+@mcp.tool
+async def save_schedule(
+    name: str,
+    sections: list[str],
+    semester: str | None = None,
+    schedule_id: int | None = None,
+) -> dict[str, Any]:
+    """Save a schedule to your Penn Course Plan account so it appears on the website.
+
+    Creates a new schedule named ``name`` containing the given ``sections`` (full
+    section ids like 'CIS-1200-001'). Pass an existing ``schedule_id`` to overwrite
+    that schedule instead of creating a new one. **Writes to your live Penn account**
+    and requires PENN_COURSES_SESSION_COOKIE (sessionid + csrftoken).
+    """
+    client = get_client()
+    try:
+        result = await client.save_schedule(
+            name=name,
+            semester=semester,
+            section_ids=sections,
+            schedule_id=schedule_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    return {
+        "saved": True,
+        "action": "updated" if schedule_id is not None else "created",
+        "schedule_id": result.get("id", schedule_id),
+        "name": name,
+        "sections": [s.upper() for s in sections],
+        "note": "Refresh penncourseplan.com and select this schedule to see it.",
+    }
+
+
+@mcp.tool
+async def delete_schedule(schedule_id: int) -> dict[str, Any]:
+    """Delete a saved Penn Course Plan schedule by its id (requires auth).
+
+    Use ``list_schedules`` to find the id first. This permanently removes the
+    schedule from your Penn Course Plan account.
+    """
+    client = get_client()
+    try:
+        await client.delete_schedule(schedule_id)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    return {"deleted": True, "schedule_id": schedule_id}
+
+
+# --------------------------------------------------------------------------
+# entry point
+# --------------------------------------------------------------------------
+def cli() -> None:
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(
+        prog="penn-course-mcp",
+        description="MCP server for Penn course planning.",
+    )
+    parser.add_argument("--version", action="version", version=f"penn-course-mcp {__version__}")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default=os.getenv("PENN_COURSES_TRANSPORT", "stdio"),
+        help="Transport to serve (default: stdio).",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("PENN_COURSES_HOST", "127.0.0.1"),
+        help="Host for HTTP transport (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PENN_COURSES_PORT", "8000")),
+        help="Port for HTTP transport (default: 8000).",
+    )
+    args = parser.parse_args()
+
+    if args.transport == "http":
+        mcp.run(transport="http", host=args.host, port=args.port)
+    else:
+        mcp.run()
+
+
+if __name__ == "__main__":
+    cli()

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str):
+    with open(FIXTURES / name) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def options_fixture():
+    return load_fixture("options.json")
+
+
+@pytest.fixture
+def search_fixture():
+    return load_fixture("search_cis1200.json")
+
+
+@pytest.fixture
+def course_fixture():
+    return load_fixture("course_cis1200.json")
+
+
+@pytest.fixture
+def math_fixture():
+    return load_fixture("course_math1400.json")

--- a/mcp/tests/fixtures/course_cis1200.json
+++ b/mcp/tests/fixtures/course_cis1200.json
@@ -1,0 +1,910 @@
+{
+  "id": "CIS-1200",
+  "title": "Prog Lang & Tech I",
+  "description": "A fast-paced introduction to the fundamental concepts of programming and software design. This course assumes some previous programming experience, at the level of a high school computer science class or CIS 1100. (If you got at least 4 in the AP Computer Science A or AB exam, you will do great.) No specific programming language background is assumed: basic experience with any language (for instance Java, C, C++, VB, Python, Perl, or Scheme) is fine. If you have never programmed before, you should take CIS 1100 first.",
+  "syllabus_url": null,
+  "semester": "2026C",
+  "prerequisites": "",
+  "course_quality": 2.807,
+  "instructor_quality": 2.872,
+  "difficulty": 3.04,
+  "work_required": 3.329,
+  "credits": 1.0,
+  "crosslistings": [],
+  "pre_ngss_requirements": [],
+  "attributes": [
+    {
+      "code": "ACSE",
+      "school": "SAS",
+      "description": "COMM C NonC-DNSC Elec"
+    },
+    {
+      "code": "ADEL",
+      "school": "SAS",
+      "description": "DSGN M Elective"
+    },
+    {
+      "code": "EUNG",
+      "school": "SEAS",
+      "description": "SEAS Engineering"
+    },
+    {
+      "code": "ALNR",
+      "school": "SAS",
+      "description": "ASLD Related Courses"
+    },
+    {
+      "code": "ALCN",
+      "school": "SAS",
+      "description": "LGIC Minor- Logic, Info, and Computing Elective"
+    },
+    {
+      "code": "AU16",
+      "school": "SAS",
+      "description": "College 16 CU Requiremen"
+    },
+    {
+      "code": "ACGC",
+      "school": "SAS",
+      "description": "COGS Computation and Cognition"
+    },
+    {
+      "code": "QU",
+      "school": "MODE",
+      "description": "Grade Mode: Stsfctry/Unstsftry"
+    },
+    {
+      "code": "QS",
+      "school": "MODE",
+      "description": "Grade Mode: Standard Lettr Grd"
+    },
+    {
+      "code": "QP",
+      "school": "MODE",
+      "description": "Grade Mode: Pass/Fail"
+    },
+    {
+      "code": "AUFR",
+      "school": "SAS",
+      "description": "COL Foundational Appr. - Formal Reason&Analysis"
+    },
+    {
+      "code": "WUNM",
+      "school": "WH",
+      "description": "Wharton UG General Education - Nat Sci, Math, Eng"
+    },
+    {
+      "code": "NURS",
+      "school": "NUR",
+      "description": "NU Sector ReaSys&Relationship"
+    }
+  ],
+  "sections": [
+    {
+      "id": "CIS-1200-001",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 1.0,
+      "capacity": 240,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 10.15,
+          "end": 11.14,
+          "room": "STIT 261"
+        },
+        {
+          "day": "M",
+          "start": 10.15,
+          "end": 11.14,
+          "room": "STIT 261"
+        },
+        {
+          "day": "W",
+          "start": 10.15,
+          "end": 11.14,
+          "room": "STIT 261"
+        }
+      ],
+      "instructors": [
+        {
+          "id": 6,
+          "name": "Swapneel Sheth"
+        },
+        {
+          "id": 4764,
+          "name": "Benjamin Pierce"
+        }
+      ],
+      "course_quality": 2.862,
+      "instructor_quality": 3.088,
+      "difficulty": 3.025,
+      "work_required": 3.269,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-223",
+          "activity": ""
+        },
+        {
+          "id": "CIS-1200-222",
+          "activity": ""
+        },
+        {
+          "id": "CIS-1200-216",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-215",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-214",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-213",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-212",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-211",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-210",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-209",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-208",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-207",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-206",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-205",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-204",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-203",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-202",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-201",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-217",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-218",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-002",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 1.0,
+      "capacity": 240,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 12.0,
+          "end": 12.59,
+          "room": "STIT 261"
+        },
+        {
+          "day": "M",
+          "start": 12.0,
+          "end": 12.59,
+          "room": "STIT 261"
+        },
+        {
+          "day": "W",
+          "start": 12.0,
+          "end": 12.59,
+          "room": "STIT 261"
+        }
+      ],
+      "instructors": [
+        {
+          "id": 6,
+          "name": "Swapneel Sheth"
+        },
+        {
+          "id": 4764,
+          "name": "Benjamin Pierce"
+        }
+      ],
+      "course_quality": 2.862,
+      "instructor_quality": 3.088,
+      "difficulty": 3.025,
+      "work_required": 3.269,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-223",
+          "activity": ""
+        },
+        {
+          "id": "CIS-1200-222",
+          "activity": ""
+        },
+        {
+          "id": "CIS-1200-216",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-215",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-214",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-213",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-212",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-211",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-210",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-209",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-208",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-207",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-206",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-205",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-204",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-203",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-202",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-201",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-217",
+          "activity": "REC"
+        },
+        {
+          "id": "CIS-1200-218",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-201",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 12.0,
+          "end": 12.59,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-202",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 13.45,
+          "end": 14.44,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-203",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 13.45,
+          "end": 14.44,
+          "room": "AGH 216B"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-204",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 15.3,
+          "end": 16.29,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-205",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 15.3,
+          "end": 16.29,
+          "room": "AGH 216B"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-206",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 17.15,
+          "end": 18.14,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-207",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 17.15,
+          "end": 18.14,
+          "room": "AGH 216B"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-208",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 19.0,
+          "end": 19.59,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-209",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 13.45,
+          "end": 14.44,
+          "room": "AGH 214"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-210",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 12.0,
+          "end": 12.59,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-211",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 12.0,
+          "end": 12.59,
+          "room": "AGH 216B"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-212",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 13.45,
+          "end": 14.44,
+          "room": "AGH 200"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-213",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 13.45,
+          "end": 14.44,
+          "room": "AGH 216B"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-214",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 15.3,
+          "end": 16.29,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-215",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 15.3,
+          "end": 16.29,
+          "room": "AGH 216B"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-216",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 17.15,
+          "end": 18.14,
+          "room": "AGH 216A"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-217",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "W",
+          "start": 15.3,
+          "end": 16.29,
+          "room": "AGH 214"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "CIS-1200-218",
+      "status": "O",
+      "activity": "REC",
+      "credits": 0.0,
+      "capacity": 20,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 15.3,
+          "end": 16.29,
+          "room": "AGH 214"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "CIS-1200-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "CIS-1200-002",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    }
+  ]
+}

--- a/mcp/tests/fixtures/course_math1400.json
+++ b/mcp/tests/fixtures/course_math1400.json
@@ -1,0 +1,1553 @@
+{
+  "id": "MATH-1400",
+  "title": "Calculus I",
+  "description": "Brief review of High School calculus, applications of integrals, transcendental functions, methods of integration, infinite series, Taylor's theorem, and first order ordinary differential equations. Use of symbolic manipulation and graphics software in calculus.\nNon-LPS students interested in this course should contact the MATH department for permission. LPS students may register via Courses@Penn.",
+  "syllabus_url": null,
+  "semester": "2026C",
+  "prerequisites": "",
+  "course_quality": 1.963,
+  "instructor_quality": 2.349,
+  "difficulty": 3.183,
+  "work_required": 3.038,
+  "credits": 1.0,
+  "crosslistings": [],
+  "pre_ngss_requirements": [],
+  "attributes": [
+    {
+      "code": "WUFG",
+      "school": "WH",
+      "description": "Wharton UG Core Flex GenEd"
+    },
+    {
+      "code": "ACGN",
+      "school": "SAS",
+      "description": "COGS Cognitive Neuroscience"
+    },
+    {
+      "code": "ACGL",
+      "school": "SAS",
+      "description": "COGS Language & Mind"
+    },
+    {
+      "code": "ACGC",
+      "school": "SAS",
+      "description": "COGS Computation and Cognition"
+    },
+    {
+      "code": "QS",
+      "school": "MODE",
+      "description": "Grade Mode: Standard Lettr Grd"
+    },
+    {
+      "code": "QP",
+      "school": "MODE",
+      "description": "Grade Mode: Pass/Fail"
+    },
+    {
+      "code": "APPR",
+      "school": "SAS",
+      "description": "PPE Rigorous Reasoning"
+    },
+    {
+      "code": "ABBN",
+      "school": "SAS",
+      "description": "NRSC Minor Course Elective"
+    },
+    {
+      "code": "ABBM",
+      "school": "SAS",
+      "description": "NRSC Major Elective"
+    },
+    {
+      "code": "AUFR",
+      "school": "SAS",
+      "description": "COL Foundational Appr. - Formal Reason&Analysis"
+    },
+    {
+      "code": "EUMA",
+      "school": "SEAS",
+      "description": "SEAS Mathematics Elective"
+    },
+    {
+      "code": "TLPS",
+      "school": null,
+      "description": "Tuition LPS Course"
+    },
+    {
+      "code": "NURS",
+      "school": "NUR",
+      "description": "NU Sector ReaSys&Relationship"
+    }
+  ],
+  "sections": [
+    {
+      "id": "MATH-1400-001",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 0.0,
+      "capacity": 94,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB A2"
+        },
+        {
+          "day": "T",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB A2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-201",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-202",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-203",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-204",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-205",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-206",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-207",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-208",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-209",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-211",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-212",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-213",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-214",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-215",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-216",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-210",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-217",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-218",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-219",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-220",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-002",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 0.0,
+      "capacity": 160,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB A1"
+        },
+        {
+          "day": "T",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB A1"
+        }
+      ],
+      "instructors": [
+        {
+          "id": 369,
+          "name": "Nakia Rimmer"
+        }
+      ],
+      "course_quality": 2.433,
+      "instructor_quality": 3.188,
+      "difficulty": 3.229,
+      "work_required": 3.127,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-201",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-202",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-203",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-204",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-205",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-206",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-207",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-208",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-209",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-211",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-212",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-213",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-214",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-215",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-216",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-210",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-217",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-218",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-219",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-220",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-003",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 0.0,
+      "capacity": 160,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 12.0,
+          "end": 13.29,
+          "room": "DRLB A1"
+        },
+        {
+          "day": "T",
+          "start": 12.0,
+          "end": 13.29,
+          "room": "DRLB A1"
+        }
+      ],
+      "instructors": [
+        {
+          "id": 369,
+          "name": "Nakia Rimmer"
+        }
+      ],
+      "course_quality": 2.433,
+      "instructor_quality": 3.188,
+      "difficulty": 3.229,
+      "work_required": 3.127,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-201",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-202",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-203",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-204",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-205",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-206",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-207",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-208",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-209",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-211",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-212",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-213",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-214",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-215",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-216",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-210",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-217",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-218",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-219",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-220",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-004",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 0.0,
+      "capacity": 160,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB A1"
+        },
+        {
+          "day": "T",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB A1"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-201",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-202",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-203",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-204",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-205",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-206",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-207",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-208",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-209",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-211",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-212",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-213",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-214",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-215",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-216",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-210",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-217",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-218",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-219",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-220",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-005",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 0.0,
+      "capacity": 94,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "R",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB A4"
+        },
+        {
+          "day": "T",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB A4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-201",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-202",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-203",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-204",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-205",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-206",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-207",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-208",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-209",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-211",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-212",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-213",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-214",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-215",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-216",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-210",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-217",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-218",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-219",
+          "activity": "REC"
+        },
+        {
+          "id": "MATH-1400-220",
+          "activity": "REC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-201",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB 4C6"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-202",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB A4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-203",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB 2C8"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-204",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB 2C8"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-205",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB 2C8"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-206",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB 2C6"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-207",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB 3W2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-208",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB 4C4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-209",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB 4C4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-210",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB 4C6"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-211",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB 3C6"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-212",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 33,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB 2C4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-213",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB 4C2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-214",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB 2C8"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-215",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB 3C4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-216",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB 4C2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-217",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 8.3,
+          "end": 9.59,
+          "room": "DRLB 3W2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-218",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 10.15,
+          "end": 11.44,
+          "room": "DRLB 4C4"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-219",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 13.45,
+          "end": 15.14,
+          "room": "DRLB 3C2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-220",
+      "status": "O",
+      "activity": "REC",
+      "credits": 1.0,
+      "capacity": 34,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "F",
+          "start": 15.3,
+          "end": 16.59,
+          "room": "DRLB 3W2"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [
+        {
+          "id": "MATH-1400-001",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-002",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-003",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-004",
+          "activity": "LEC"
+        },
+        {
+          "id": "MATH-1400-005",
+          "activity": "LEC"
+        }
+      ],
+      "registration_volume": 0
+    },
+    {
+      "id": "MATH-1400-601",
+      "status": "O",
+      "activity": "LEC",
+      "credits": 1.0,
+      "capacity": 30,
+      "semester": "2026C",
+      "meetings": [
+        {
+          "day": "M",
+          "start": 19.0,
+          "end": 20.59,
+          "room": "DRLB 3C6"
+        },
+        {
+          "day": "W",
+          "start": 19.0,
+          "end": 20.59,
+          "room": "DRLB 3C6"
+        }
+      ],
+      "instructors": [],
+      "course_quality": null,
+      "instructor_quality": null,
+      "difficulty": null,
+      "work_required": null,
+      "associated_sections": [],
+      "registration_volume": 0
+    }
+  ]
+}

--- a/mcp/tests/fixtures/options.json
+++ b/mcp/tests/fixtures/options.json
@@ -1,0 +1,6 @@
+{
+  "RECRUITING": false,
+  "SEMESTER": "2026C",
+  "REGISTRATION_OPEN": true,
+  "SEND_FROM_WEBHOOK": true
+}

--- a/mcp/tests/fixtures/search_cis1200.json
+++ b/mcp/tests/fixtures/search_cis1200.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "CIS-1200",
+    "title": "Prog Lang & Tech I",
+    "description": "A fast-paced introduction to the fundamental concepts of programming and software design. This course assumes some previous programming experience, at the level of a high school computer science class or CIS 1100. (If you got at least 4 in the AP Computer Science A or AB exam, you will do great.) No specific programming language background is assumed: basic experience with any language (for instance Java, C, C++, VB, Python, Perl, or Scheme) is fine. If you have never programmed before, you should take CIS 1100 first.",
+    "semester": "2026C",
+    "num_sections": 20,
+    "course_quality": 2.807,
+    "instructor_quality": 2.872,
+    "difficulty": 3.04,
+    "work_required": 3.329,
+    "recommendation_score": null,
+    "credits": 1.0
+  }
+]

--- a/mcp/tests/test_client.py
+++ b/mcp/tests/test_client.py
@@ -1,0 +1,97 @@
+import httpx
+import pytest
+import respx
+
+from penn_course_mcp.client import PennCoursesClient
+from penn_course_mcp.config import Settings
+from penn_course_mcp.errors import CourseNotFound, ReviewAuthRequired
+
+
+BASE = "https://penncoursereview.com"
+
+
+def make_client(**overrides) -> PennCoursesClient:
+    settings = Settings(base_url=BASE, semester="current", cache_ttl=3600, **overrides)
+    return PennCoursesClient(settings)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resolve_semester_from_options(options_fixture):
+    route = respx.get(f"{BASE}/api/options/").mock(
+        return_value=httpx.Response(200, json=options_fixture)
+    )
+    client = make_client()
+    sem = await client.resolve_semester("current")
+    assert sem == options_fixture["SEMESTER"]
+    # second resolution is cached -> no second request
+    await client.resolve_semester(None)
+    assert route.call_count == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resolve_semester_passthrough():
+    client = make_client()
+    assert await client.resolve_semester("2025A") == "2025A"
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_course_caches(options_fixture, course_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    route = respx.get(f"{BASE}/api/base/{sem}/courses/CIS-1200/").mock(
+        return_value=httpx.Response(200, json=course_fixture)
+    )
+    client = make_client()
+    a = await client.get_course("current", "CIS-1200")
+    b = await client.get_course(None, "cis-1200")  # lowercased + cached
+    assert a["id"] == b["id"] == "CIS-1200"
+    assert route.call_count == 1
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_course_not_found(options_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/courses/ZZZ-9999/").mock(return_value=httpx.Response(404))
+    client = make_client()
+    with pytest.raises(CourseNotFound):
+        await client.get_course("current", "ZZZ-9999")
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_review_requires_cookie():
+    client = make_client()  # no session cookie
+    with pytest.raises(ReviewAuthRequired):
+        await client.get_review("CIS-1200")
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_review_403_maps_to_auth_required():
+    respx.get(f"{BASE}/api/review/course/CIS-1200").mock(return_value=httpx.Response(403))
+    client = make_client(session_cookie="sessionid=bad")
+    with pytest.raises(ReviewAuthRequired):
+        await client.get_review("CIS-1200")
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_review_success():
+    respx.get(f"{BASE}/api/review/course/CIS-1200").mock(
+        return_value=httpx.Response(200, json={"code": "CIS-1200", "reviews": []})
+    )
+    client = make_client(session_cookie="sessionid=good")
+    data = await client.get_review("CIS-1200")
+    assert data["code"] == "CIS-1200"
+    await client.aclose()

--- a/mcp/tests/test_planning.py
+++ b/mcp/tests/test_planning.py
@@ -1,0 +1,131 @@
+import pytest
+
+from penn_course_mcp.planning import (
+    build_schedule,
+    compare_courses,
+    detect_conflicts,
+    filter_courses_by_attribute,
+    fmt_time,
+    meetings_overlap,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (10.15, "10:15"),
+        (11.14, "11:14"),
+        (15.3, "15:30"),
+        (12.0, "12:00"),
+        (12.59, "12:59"),
+        (9.0, "09:00"),
+        (19.59, "19:59"),
+        (None, "TBA"),
+    ],
+)
+def test_fmt_time(value, expected):
+    assert fmt_time(value) == expected
+
+
+def m(day, start, end, room="X"):
+    return {"day": day, "start": start, "end": end, "room": room}
+
+
+def test_meetings_overlap_same_time_same_day():
+    assert meetings_overlap(m("M", 10.0, 11.0), m("M", 10.3, 10.45)) is True
+
+
+def test_meetings_overlap_touching_is_not_conflict():
+    # one ends exactly when the next begins -> NOT a conflict (strict <)
+    assert meetings_overlap(m("M", 10.0, 11.0), m("M", 11.0, 12.0)) is False
+
+
+def test_meetings_overlap_disjoint():
+    assert meetings_overlap(m("M", 10.0, 11.0), m("M", 13.0, 14.0)) is False
+
+
+def test_meetings_overlap_different_day():
+    assert meetings_overlap(m("M", 10.0, 11.0), m("T", 10.0, 11.0)) is False
+
+
+def test_meetings_overlap_tba_is_not_conflict():
+    assert meetings_overlap(m("M", None, None), m("M", 10.0, 11.0)) is False
+
+
+def test_detect_conflicts_three_sections_one_overlap():
+    sections = [
+        {"id": "A-001", "meetings": [m("M", 10.0, 11.0)]},
+        {"id": "B-001", "meetings": [m("M", 10.3, 11.3)]},  # conflicts with A
+        {"id": "C-001", "meetings": [m("T", 10.0, 11.0)]},  # no conflict
+    ]
+    conflicts = detect_conflicts(sections)
+    assert len(conflicts) == 1
+    pair = {conflicts[0]["section_a"], conflicts[0]["section_b"]}
+    assert pair == {"A-001", "B-001"}
+
+
+def test_build_schedule_credits_and_grid():
+    sections = [
+        {"id": "A-001", "credits": 1.0, "meetings": [m("M", 9.0, 10.0)]},
+        {"id": "B-001", "credits": 0.5, "meetings": [m("W", 13.3, 14.3)]},
+    ]
+    result = build_schedule(sections)
+    assert result["total_credits"] == 1.5
+    assert result["has_conflicts"] is False
+    assert "Monday" in result["weekly_grid"]
+    assert result["weekly_grid"]["Monday"][0]["start"] == "09:00"
+
+
+def test_build_schedule_missing_associated_warning():
+    sections = [
+        {
+            "id": "CIS-1200-001",
+            "credits": 1.0,
+            "meetings": [m("M", 10.0, 11.0)],
+            "associated_sections": [{"id": "CIS-1200-201", "activity": "REC"}],
+        }
+    ]
+    result = build_schedule(sections)
+    assert result["warnings"]
+    assert "CIS-1200-201" in result["warnings"][0]
+
+
+def test_build_schedule_associated_satisfied_no_warning():
+    sections = [
+        {
+            "id": "CIS-1200-001",
+            "credits": 1.0,
+            "meetings": [m("M", 10.0, 11.0)],
+            "associated_sections": [{"id": "CIS-1200-201", "activity": "REC"}],
+        },
+        {"id": "CIS-1200-201", "credits": 0.0, "meetings": [m("F", 14.0, 15.0)]},
+    ]
+    result = build_schedule(sections)
+    assert result["warnings"] == []
+
+
+def test_compare_courses():
+    details = [
+        {"id": "CIS-1200", "title": "PL I", "course_quality": 2.8, "credits": 1.0},
+        {"id": "CIS-1600", "title": "Math Found", "course_quality": 3.1, "credits": 1.0},
+    ]
+    result = compare_courses(details)
+    assert result["courses"] == ["CIS-1200", "CIS-1600"]
+    assert len(result["comparison"]) == 2
+
+
+def test_filter_courses_by_attribute_code():
+    courses = [
+        {"id": "A", "attributes": [{"code": "EUMS", "description": "Euro studies"}]},
+        {"id": "B", "attributes": [{"code": "MFR", "description": "Formal reasoning"}]},
+    ]
+    assert [c["id"] for c in filter_courses_by_attribute(courses, "MFR")] == ["B"]
+
+
+def test_filter_courses_by_attribute_description_substring():
+    courses = [
+        {"id": "A", "attributes": [{"code": "EUMS", "description": "Euro studies"}]},
+        {"id": "B", "attributes": [{"code": "MFR", "description": "Formal reasoning"}]},
+    ]
+    matched = filter_courses_by_attribute(courses, "reasoning", match="description")
+    assert [c["id"] for c in matched] == ["B"]

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -1,0 +1,219 @@
+import httpx
+import pytest
+import respx
+
+import penn_course_mcp.server as server
+from penn_course_mcp.client import PennCoursesClient
+from penn_course_mcp.config import Settings
+
+
+BASE = "https://penncoursereview.com"
+
+
+@pytest.fixture
+def wire_client(monkeypatch):
+    """Point the server's global client at a respx-mockable instance."""
+
+    def _make(session_cookie=None):
+        settings = Settings(base_url=BASE, semester="current", session_cookie=session_cookie)
+        client = PennCoursesClient(settings)
+        monkeypatch.setattr(server, "_client", client)
+        return client
+
+    return _make
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_current_semester(wire_client, options_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    wire_client()
+    out = await server.get_current_semester()
+    assert out["semester"] == options_fixture["SEMESTER"]
+    assert out["reviews_enabled"] is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_courses_limit(wire_client, options_fixture, search_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/search/courses/").mock(
+        return_value=httpx.Response(200, json=search_fixture)
+    )
+    wire_client()
+    out = await server.search_courses("CIS-1200", limit=1)
+    assert out["count"] == len(search_fixture)
+    assert len(out["results"]) <= 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_course_details_formats_meetings(wire_client, options_fixture, course_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/courses/CIS-1200/").mock(
+        return_value=httpx.Response(200, json=course_fixture)
+    )
+    wire_client()
+    out = await server.get_course_details("CIS-1200")
+    assert out["id"] == "CIS-1200"
+    # meetings should be human-readable strings, not raw decimals
+    first = out["sections"][0]
+    assert all(isinstance(mt, str) for mt in first["meetings"])
+    assert any(":" in mt for mt in first["meetings"])
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_course_not_found_returns_error(wire_client, options_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/courses/ZZZ-9999/").mock(return_value=httpx.Response(404))
+    wire_client()
+    out = await server.get_course_details("ZZZ-9999")
+    assert "error" in out
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_reviews_degrade_without_cookie(wire_client, options_fixture, course_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/courses/CIS-1200/").mock(
+        return_value=httpx.Response(200, json=course_fixture)
+    )
+    wire_client(session_cookie=None)
+    out = await server.get_course_reviews("CIS-1200")
+    assert out["auth_status"] == "unauthenticated"
+    assert "aggregate_ratings" in out
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_reviews_authenticated(wire_client):
+    respx.get(f"{BASE}/api/review/course/CIS-1200").mock(
+        return_value=httpx.Response(200, json={"code": "CIS-1200", "instructors": []})
+    )
+    wire_client(session_cookie="sessionid=good")
+    out = await server.get_course_reviews("CIS-1200")
+    assert out["auth_status"] == "authenticated"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_check_schedule_conflicts(wire_client, options_fixture, course_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/courses/CIS-1200/").mock(
+        return_value=httpx.Response(200, json=course_fixture)
+    )
+    wire_client()
+    # two lecture sections of the same course almost certainly clash or not;
+    # at minimum the tool resolves them and returns a structured result.
+    first_two = [s["id"] for s in course_fixture["sections"][:2]]
+    out = await server.check_schedule_conflicts(first_two)
+    assert "has_conflicts" in out
+    assert out["not_found"] == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_build_schedule_reports_credits(wire_client, options_fixture, course_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    respx.get(f"{BASE}/api/base/{sem}/courses/CIS-1200/").mock(
+        return_value=httpx.Response(200, json=course_fixture)
+    )
+    wire_client()
+    sid = course_fixture["sections"][0]["id"]
+    out = await server.build_schedule([sid])
+    assert "total_credits" in out
+    assert "weekly_grid" in out
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_recommend_courses_sorts(wire_client, options_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    sem = options_fixture["SEMESTER"]
+    payload = [
+        {"id": "A", "course_quality": 2.0},
+        {"id": "B", "course_quality": 3.5},
+        {"id": "C", "course_quality": None},
+    ]
+    respx.get(f"{BASE}/api/base/{sem}/search/courses/").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    wire_client()
+    out = await server.recommend_courses("anything", sort_by="course_quality")
+    assert out["results"][0]["id"] == "B"  # highest quality first
+    assert out["results"][-1]["id"] == "C"  # unrated last
+
+
+# -- schedule writes -------------------------------------------------------
+@pytest.mark.asyncio
+@respx.mock
+async def test_save_schedule_requires_auth(wire_client):
+    wire_client(session_cookie=None)
+    out = await server.save_schedule("My Plan", ["CIS-1200-001"])
+    assert "error" in out
+    assert "PENN_COURSES_SESSION_COOKIE" in out["hint"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_save_schedule_creates(wire_client, options_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    route = respx.post(f"{BASE}/api/plan/schedules/").mock(
+        return_value=httpx.Response(201, json={"message": "success", "id": 12345})
+    )
+    wire_client(session_cookie="sessionid=good; csrftoken=tok")
+    out = await server.save_schedule("My Plan", ["cis-1200-001"])
+    assert out["saved"] is True
+    assert out["action"] == "created"
+    assert out["schedule_id"] == 12345
+    # CSRF token forwarded; section code normalized to upper-case in the payload
+    req = route.calls.last.request
+    assert req.headers.get("x-csrftoken") == "tok"
+    assert b"CIS-1200-001" in req.content
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_save_schedule_updates_existing(wire_client, options_fixture):
+    respx.get(f"{BASE}/api/options/").mock(return_value=httpx.Response(200, json=options_fixture))
+    route = respx.put(f"{BASE}/api/plan/schedules/999/").mock(
+        return_value=httpx.Response(200, json={"id": 999})
+    )
+    wire_client(session_cookie="sessionid=good; csrftoken=tok")
+    out = await server.save_schedule("Plan", ["CIS-1600-001"], schedule_id=999)
+    assert out["action"] == "updated"
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_list_schedules(wire_client):
+    respx.get(f"{BASE}/api/plan/schedules/").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"id": 1, "name": "S", "semester": "2026C", "sections": [{"id": "CIS-1200-001"}]}
+            ],
+        )
+    )
+    wire_client(session_cookie="sessionid=good; csrftoken=tok")
+    out = await server.list_schedules()
+    assert out["count"] == 1
+    assert out["schedules"][0]["sections"] == ["CIS-1200-001"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_delete_schedule(wire_client):
+    route = respx.delete(f"{BASE}/api/plan/schedules/77/").mock(return_value=httpx.Response(204))
+    wire_client(session_cookie="sessionid=good; csrftoken=tok")
+    out = await server.delete_schedule(77)
+    assert out["deleted"] is True
+    assert route.called


### PR DESCRIPTION
Hi Penn Labs team,

I'm Grant, an incoming Wharton student transferring in this fall from the University of Richmond. I was using Penn Course Plan and Penn Course Review, and I built a small Model Context Protocol (MCP) server on top of the public Penn Courses API so I could do course planning from an LLM client like Claude. This PR offers it back to the project as a new mcp/ component, in case it's useful.

**What it adds**
A standalone MCP server under mcp/ that lets an MCP client search the catalog, read sections, ratings, and reviews, detect schedule conflicts, build a weekly schedule, and (with a logged-in session cookie) read and save schedules on a Penn Course Plan account. The full tool list and setup live in mcp/README.md.

**How it fits the repo**
- It talks to the API over HTTP and does not import the Django backend, so it sits in its own top-level directory and runs independently, much like frontend/.
- I tried to match the backend's conventions: black (line length 100), flake8 with flake8-quotes and flake8-isort, and isort, configured the same way through setup.cfg and pyproject.toml.
- It includes unit tests for the network-free planning logic (41 tests, probably too many) and an optional Claude skill with usage guidance.
- The only change outside mcp/ is a single link added to the root README.


I used Claude Code to help build and polish this. I think it came out clean and I tested it against the live API, but I know an AI-assisted contribution that drops a new component into your monorepo is a big ask, and the last thing I want is to slop up your codebase. So if this isn't something you want to take on, no worries at all, I completely understand and I'm happy to close it. I'm also glad to trim the scope, change the structure, or move it out of the monorepo if you'd prefer.

Thanks for maintaining Penn Courses.

Best,
Grant

gdehoog@wharton.upenn.edu is my email