### PR TITLE
Backend pcr-redesign

### DIFF
--- a/backend/courses/filters.py
+++ b/backend/courses/filters.py
@@ -314,6 +314,20 @@ def choice_filter(field):
     return filter_choices
 
 
+def department_filter(queryset, departments):
+    """
+    Filters courses by department code(s) with OR logic.
+    :param queryset: Course queryset
+    :param departments: Pipe-separated department codes (e.g. "CIS|NETS|ESE")
+    """
+    if not departments:
+        return queryset
+    codes = [code.strip().upper() for code in departments.split("|") if code.strip()]
+    if not codes:
+        return queryset
+    return queryset.filter(department__code__in=codes)
+
+
 def degree_rules_filter(queryset, rule_ids):
     """
     :param queryset: initial Course object queryset
@@ -347,6 +361,7 @@ class CourseSearchFilterBackend(filters.BaseFilterBackend):
             "difficulty": bound_filter("difficulty"),
             "is_open": is_open_filter,
             "rule_ids": degree_rules_filter,
+            "departments": department_filter,
         }
         for field, filter_func in filters.items():
             param = request.query_params.get(field)

--- a/backend/courses/filters.py
+++ b/backend/courses/filters.py
@@ -560,3 +560,4 @@ class CourseSearchFilterBackend(filters.BaseFilterBackend):
                 "example": "true",
             },
         ]
+    

--- a/backend/courses/filters.py
+++ b/backend/courses/filters.py
@@ -560,4 +560,3 @@ class CourseSearchFilterBackend(filters.BaseFilterBackend):
                 "example": "true",
             },
         ]
-    

--- a/backend/courses/views.py
+++ b/backend/courses/views.py
@@ -76,7 +76,8 @@ class BaseCourseMixin(AutoPrefetchViewSetMixin, generics.GenericAPIView):
             queryset = queryset.filter(**{self.get_semester_field(): semester})
         else:  # Only used for Penn Degree Plan (as of 4/10/2024)
             queryset = (
-                queryset.exclude(credits=None)  # heuristic: if the credits are empty, then ignore
+                # heuristic: if the credits are empty, then ignore
+                queryset.exclude(credits=None)
                 .order_by("full_code", "-semester")
                 .distinct("full_code")
             )
@@ -107,7 +108,8 @@ class SectionList(generics.ListAPIView, BaseCourseMixin):
     )
 
     serializer_class = MiniSectionSerializer
-    queryset = Section.objects.none()  # Default for documentation; overridden in get_queryset
+    # Default for documentation; overridden in get_queryset
+    queryset = Section.objects.none()
     filter_backends = [TypedSectionSearchBackend]
     search_fields = ["^full_code"]
 
@@ -137,7 +139,8 @@ class SectionDetail(generics.RetrieveAPIView, BaseCourseMixin):
     )
 
     serializer_class = SectionDetailSerializer
-    queryset = Section.objects.none()  # Default for documentation; overridden in get_queryset
+    # Default for documentation; overridden in get_queryset
+    queryset = Section.objects.none()
     lookup_field = "full_code"
 
     def get_queryset(self):
@@ -185,12 +188,14 @@ class CourseList(generics.ListAPIView, BaseCourseMixin):
 
     # These params filter on schedule/section data that only exists in a specific semester,
     # so requesting them on the "all" semester path is an error.
-    _SEMESTER_SPECIFIC_PARAMS = frozenset({"days", "time", "instructor_quality"})
+    _SEMESTER_SPECIFIC_PARAMS = frozenset(
+        {"days", "time", "instructor_quality"})
 
     def get_semester(self):
         semester = super().get_semester()
         if semester == "all":
-            bad_params = sorted(self._SEMESTER_SPECIFIC_PARAMS.intersection(self.request.query_params))
+            bad_params = sorted(self._SEMESTER_SPECIFIC_PARAMS.intersection(
+                self.request.query_params))
             if bad_params:
                 raise ValidationError(
                     f"The query parameter(s) {', '.join(bad_params)} cannot be used with "
@@ -325,15 +330,18 @@ class CourseDetail(generics.RetrieveAPIView, BaseCourseMixin):
     def get_serializer_context(self):
         context = super().get_serializer_context()
         if self.request and hasattr(self.request, "query_params"):
-            include_location_str = self.request.query_params.get("include_location", "False")
-            context.update({"include_location": include_location_str.lower() == "true"})
+            include_location_str = self.request.query_params.get(
+                "include_location", "False")
+            context.update(
+                {"include_location": include_location_str.lower() == "true"})
         else:
             context.update({"include_location": False})
         return context
 
     def get_queryset(self):
         queryset = Course.with_reviews.all()
-        include_location = self.request.query_params.get("include_location", False)
+        include_location = self.request.query_params.get(
+            "include_location", False)
 
         prefetch_list = [
             "course",
@@ -579,7 +587,8 @@ class FriendshipView(generics.ListAPIView):
     def get_queryset(self):
         return Friendship.objects.filter(
             Q(sender=self.request.user) | Q(recipient=self.request.user),
-            Q(status=Friendship.Status.ACCEPTED) | Q(status=Friendship.Status.SENT),
+            Q(status=Friendship.Status.ACCEPTED) | Q(
+                status=Friendship.Status.SENT),
         )
 
     # returns all friendships (regardless of status)
@@ -598,7 +607,8 @@ class FriendshipView(generics.ListAPIView):
         recipient = get_object_or_404(User, username=username.lower())
 
         existing_friendship = (
-            self.get_all_friendships().filter(Q(recipient=recipient) | Q(sender=recipient)).first()
+            self.get_all_friendships().filter(Q(recipient=recipient)
+                                              | Q(sender=recipient)).first()
         )
 
         if not existing_friendship:
@@ -640,7 +650,8 @@ class FriendshipView(generics.ListAPIView):
         recipient = get_object_or_404(User, username=username.lower())
 
         existing_friendship = (
-            self.get_all_friendships().filter(Q(recipient=recipient) | Q(sender=recipient)).first()
+            self.get_all_friendships().filter(Q(recipient=recipient)
+                                              | Q(sender=recipient)).first()
         )
         if not existing_friendship:
             res["message"] = "Friendship doesn't exist."

--- a/backend/courses/views.py
+++ b/backend/courses/views.py
@@ -156,6 +156,7 @@ class OptionalPageNumberPagination(PageNumberPagination):
 
     page_size_query_param = "page_size"
     page_size = 100
+    max_page_size = 500
 
     def paginate_queryset(self, queryset, request, view=None):
         if "page" not in request.query_params and "page_size" not in request.query_params:
@@ -178,7 +179,23 @@ class CourseList(generics.ListAPIView, BaseCourseMixin):
     )
 
     serializer_class = CourseListSerializer
+    pagination_class = OptionalPageNumberPagination
+    filter_backends = [CourseSearchFilterBackend]
     queryset = Course.objects.none()  # included redundantly for docs
+
+    # These params filter on schedule/section data that only exists in a specific semester,
+    # so requesting them on the "all" semester path automatically snaps to current semester.
+    _SEMESTER_SPECIFIC_PARAMS = frozenset({"days", "time", "instructor_quality"})
+
+    def get_semester(self):
+        semester = super().get_semester()
+        if semester == "all" and self._SEMESTER_SPECIFIC_PARAMS.intersection(
+            self.request.query_params
+        ):
+            current = get_current_semester(allow_not_found=True)
+            if current:
+                return current
+        return semester
 
     def get_queryset(self):
         queryset = Course.with_reviews.filter(sections__isnull=False)
@@ -260,7 +277,6 @@ class CourseListSearch(CourseList):
 
     filter_backends = [TypedCourseSearchBackend, CourseSearchFilterBackend]
     search_fields = ("full_code", "title", "sections__instructors__name")
-    pagination_class = OptionalPageNumberPagination
 
 
 class CourseDetail(generics.RetrieveAPIView, BaseCourseMixin):

--- a/backend/courses/views.py
+++ b/backend/courses/views.py
@@ -184,17 +184,18 @@ class CourseList(generics.ListAPIView, BaseCourseMixin):
     queryset = Course.objects.none()  # included redundantly for docs
 
     # These params filter on schedule/section data that only exists in a specific semester,
-    # so requesting them on the "all" semester path automatically snaps to current semester.
+    # so requesting them on the "all" semester path is an error.
     _SEMESTER_SPECIFIC_PARAMS = frozenset({"days", "time", "instructor_quality"})
 
     def get_semester(self):
         semester = super().get_semester()
-        if semester == "all" and self._SEMESTER_SPECIFIC_PARAMS.intersection(
-            self.request.query_params
-        ):
-            current = get_current_semester(allow_not_found=True)
-            if current:
-                return current
+        if semester == "all":
+            bad_params = sorted(self._SEMESTER_SPECIFIC_PARAMS.intersection(self.request.query_params))
+            if bad_params:
+                raise ValidationError(
+                    f"The query parameter(s) {', '.join(bad_params)} cannot be used with "
+                    "semester='all'; specify a semester (or 'current') instead."
+                )
         return semester
 
     def get_queryset(self):

--- a/backend/tests/courses/test_api.py
+++ b/backend/tests/courses/test_api.py
@@ -85,6 +85,18 @@ class CourseListTestCase(TestCase):
         create_mock_data("MATH-104-001", new_sem)
         self.assertEqual(len(response.data), 2)
 
+    def test_all_semester_with_semester_specific_params_is_error(self):
+        url = reverse("courses-list", kwargs={"semester": "all"})
+        for param in ("days", "time", "instructor_quality"):
+            response = self.client.get(url, {param: "1"})
+            self.assertEqual(response.status_code, 400, response.data)
+            self.assertIn(param, str(response.data))
+        # The same params are fine on a concrete semester.
+        response = self.client.get(
+            reverse("courses-list", kwargs={"semester": TEST_SEMESTER}), {"days": "M"}
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+
     def test_course_with_no_sections_not_in_list(self):
         self.math.sections.all().delete()
         response = self.client.get(reverse("courses-list", kwargs={"semester": "all"}))


### PR DESCRIPTION
- Add a `departments` query param to CourseSearchFilterBackend that filters by pipe-separated department codes.
- Enable OptionalPageNumberPagination (capped at 500 per page) and CourseSearchFilterBackend on the base /courses/ list endpoint.
- When the "all" semester is requested with section-specific filters (days, time, instructor_quality), snap to the current semester.