### PR TITLE
Add configurable chat model providers

### DIFF
--- a/backend/PennCourses/settings/base.py
+++ b/backend/PennCourses/settings/base.py
@@ -211,6 +211,16 @@ REST_FRAMEWORK = {
 # Penn Course Chat
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 CHAT_MODEL = os.environ.get("CHAT_MODEL", "claude-sonnet-5")
+# OpenCode Go serves OpenAI-compatible Chat Completions for the two models that
+# Penn Course Chat currently supports. The key is kept server-side like the
+# Anthropic key; clients only ever receive the safe, curated model catalog.
+OPENCODE_GO_API_KEY = os.environ.get("OPENCODE_GO_API_KEY", "")
+OPENCODE_GO_BASE_URL = os.environ.get(
+    "OPENCODE_GO_BASE_URL", "https://opencode.ai/zen/go/v1"
+)
+# A fully-qualified model id from chat.providers. DeepSeek is preferred when
+# Go is configured; the registry falls back to the Anthropic model otherwise.
+CHAT_DEFAULT_MODEL = os.environ.get("CHAT_DEFAULT_MODEL", "opencode-go/deepseek-v4.1-flash")
 # Effort trades answer quality against latency; a course-search chat is interactive, so
 # it runs below the API default of "high".
 CHAT_EFFORT = os.environ.get("CHAT_EFFORT", "medium")

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,10 +48,14 @@ If you are in Penn Labs, reach out to a Penn Courses team lead for a .env file t
 ### Penn Course Chat
 
 Penn Course Chat (`POST /api/chat/`, plus `POST /api/chat/stream/` which delivers the
-same turn as Server-Sent Events; both served by the `chat` app) calls the Anthropic API and is disabled
-unless `ANTHROPIC_API_KEY` is set — without it the route returns a 503 explaining that it
-is unconfigured, and the rest of the backend is unaffected. Get a key from
-[console.anthropic.com](https://console.anthropic.com/) and add it to your `.env`.
+same turn as Server-Sent Events; both served by the `chat` app) uses whichever supported
+provider key is configured. `ANTHROPIC_API_KEY` enables the configured Claude model;
+`OPENCODE_GO_API_KEY` enables OpenCode Go's DeepSeek V4.1 Flash and GLM-5.3 models. The
+authenticated frontend reads `GET /api/chat/models/` and shows only those enabled models.
+If neither key is set, chat returns a 503 explaining that it is unconfigured, and the rest
+of the backend is unaffected. Get an Anthropic key from
+[console.anthropic.com](https://console.anthropic.com/) or an OpenCode Go key from your
+OpenCode account, then add it to `.env`.
 
 Note that nothing in this project reads `.env` automatically, so adding the key to the
 file is not enough on its own — you have to get it into the server's environment:
@@ -66,7 +70,10 @@ These optional variables tune it (defaults in parentheses):
 
 | Variable | Purpose |
 | --- | --- |
-| `CHAT_MODEL` (`claude-sonnet-5`) | Which model to call. |
+| `CHAT_MODEL` (`claude-sonnet-5`) | Anthropic model to offer when `ANTHROPIC_API_KEY` is set. |
+| `OPENCODE_GO_API_KEY` | Enables OpenCode Go's curated DeepSeek V4.1 Flash and GLM-5.3 choices. |
+| `OPENCODE_GO_BASE_URL` (`https://opencode.ai/zen/go/v1`) | OpenCode Go API base URL. |
+| `CHAT_DEFAULT_MODEL` (`opencode-go/deepseek-v4.1-flash`) | Preferred fully-qualified choice; falls back to an enabled model. |
 | `CHAT_EFFORT` (`medium`) | Reasoning effort: `low`, `medium`, `high`, `xhigh`, `max`. Higher is slower and costs more. |
 | `CHAT_MAX_TOKENS` (`4096`) | Output token cap per reply. |
 | `CHAT_MAX_TOOL_TURNS` (`16`) | Round trips to the model within one message. Each carries a batch of tool calls, so this is well above 16 lookups. Bounds latency and spend per message; hitting it abandons the turn rather than returning a partial answer. |

--- a/backend/chat/agent.py
+++ b/backend/chat/agent.py
@@ -16,9 +16,11 @@ import logging
 import re
 
 import anthropic
+import requests
 from django.conf import settings
 
 from chat.prompts import SYSTEM_PROMPT
+from chat.providers import ChatModel
 from chat.tools import TOOLS, ToolError, collect_previews, enrich_previews, run_tool
 
 
@@ -41,6 +43,26 @@ def get_client():
     return anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
 
 
+def get_opencode_client(conversation_id):
+    """Create a session with the headers OpenCode Go uses for routing and caching."""
+    if not settings.OPENCODE_GO_API_KEY:
+        raise ChatUnavailable(
+            "The course chat assistant is not configured on this server "
+            "(OPENCODE_GO_API_KEY is unset)."
+        )
+    client = requests.Session()
+    client.headers.update(
+        {
+            "Authorization": f"Bearer {settings.OPENCODE_GO_API_KEY}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "User-Agent": "penn-course-chat/1.0",
+            "x-opencode-session": conversation_id,
+        }
+    )
+    return client
+
+
 def _tool_result(tool_use_id, value, is_error=False):
     return {
         "type": "tool_result",
@@ -50,7 +72,64 @@ def _tool_result(tool_use_id, value, is_error=False):
     }
 
 
-def stream_chat_turn(messages, *, semester, user, client=None):
+OPENAI_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": tool["name"],
+            "description": tool["description"],
+            "parameters": tool["input_schema"],
+        },
+    }
+    for tool in TOOLS
+]
+
+
+def _completed_turn(reply_parts, tool_calls, previews, *, truncated):
+    """Build the provider-independent payload shared by both model adapters."""
+    reply = "".join(reply_parts).strip()
+    # A search can return dozens of courses while the reply names three. Send blurbs
+    # only for the codes the student will actually see.
+    mentioned = set(COURSE_CODE_RE.findall(reply))
+    # A code can be mentioned without ever having been looked up directly — from the
+    # student's cart, from their degree plan, or from the model's own knowledge. Start
+    # from an empty blurb for each and let the catalog fill it.
+    selected = {code: previews.get(code, {"course_code": code}) for code in sorted(mentioned)}
+    # Anything the catalog has never heard of is not a course — a regex match on
+    # something else, or a code the model invented.
+    unknown = enrich_previews(selected)
+    return {
+        "reply": reply,
+        "tool_calls": tool_calls,
+        "courses": [c for code, c in selected.items() if code not in unknown],
+        "truncated": truncated,
+    }
+
+
+def stream_chat_turn(messages, *, semester, user, client=None, model=None, conversation_id=None):
+    """Dispatch a turn to the selected provider while preserving one event protocol."""
+    model = model or ChatModel(
+        id=f"anthropic/{settings.CHAT_MODEL}",
+        api_model=settings.CHAT_MODEL,
+        label=settings.CHAT_MODEL,
+        provider="Anthropic",
+    )
+    if model.provider == "OpenCode Go":
+        yield from _stream_opencode_chat_turn(
+            messages,
+            semester=semester,
+            user=user,
+            client=client,
+            model=model,
+            conversation_id=conversation_id or f"pcx-user-{user.pk}",
+        )
+        return
+    yield from _stream_anthropic_chat_turn(
+        messages, semester=semester, user=user, client=client, model=model
+    )
+
+
+def _stream_anthropic_chat_turn(messages, *, semester, user, client=None, model=None):
     """
     Run one turn of the conversation, yielding events as they happen.
 
@@ -68,6 +147,12 @@ def stream_chat_turn(messages, *, semester, user, client=None):
     the whole turn at once should use `run_chat_turn`.
     """
     client = client or get_client()
+    model = model or ChatModel(
+        id=f"anthropic/{settings.CHAT_MODEL}",
+        api_model=settings.CHAT_MODEL,
+        label=settings.CHAT_MODEL,
+        provider="Anthropic",
+    )
 
     conversation = [dict(message) for message in messages]
     tool_calls = []
@@ -84,7 +169,7 @@ def stream_chat_turn(messages, *, semester, user, client=None):
             # calls can outlast an intermediate proxy's idle timeout, and bytes on the
             # wire keep the connection alive.
             with client.messages.stream(
-                model=settings.CHAT_MODEL,
+                model=model.api_model,
                 max_tokens=settings.CHAT_MAX_TOKENS,
                 output_config={"effort": settings.CHAT_EFFORT},
                 system=[
@@ -128,26 +213,12 @@ def stream_chat_turn(messages, *, semester, user, client=None):
             raise ChatUnavailable("The assistant declined to answer that.")
 
         if response.stop_reason != "tool_use":
-            reply = "".join(reply_parts).strip()
-            # A search can return dozens of courses while the reply names three. Send
-            # blurbs only for the codes the student will actually see.
-            mentioned = set(COURSE_CODE_RE.findall(reply))
-            # A code can be mentioned without ever having been looked up directly —
-            # from the student's cart, from their degree plan, or from the model's own
-            # knowledge. Start from an empty blurb for each and let the catalog fill
-            # it, so the card is the same wherever the course came from.
-            selected = {
-                code: previews.get(code, {"course_code": code}) for code in sorted(mentioned)
-            }
-            # Anything the catalog has never heard of is not a course — a regex match
-            # on something else, or a code the model invented.
-            unknown = enrich_previews(selected)
-            yield "done", {
-                "reply": reply,
-                "tool_calls": tool_calls,
-                "courses": [c for code, c in selected.items() if code not in unknown],
-                "truncated": response.stop_reason == "max_tokens",
-            }
+            yield "done", _completed_turn(
+                reply_parts,
+                tool_calls,
+                previews,
+                truncated=response.stop_reason == "max_tokens",
+            )
             return
 
         conversation.append({"role": "assistant", "content": response.content})
@@ -196,14 +267,169 @@ def stream_chat_turn(messages, *, semester, user, client=None):
     )
 
 
-def run_chat_turn(messages, *, semester, user, client=None):
+def _stream_opencode_chat_turn(messages, *, semester, user, client, model, conversation_id):
+    """Run the same tool loop against OpenCode Go's Chat Completions endpoint."""
+    client = client or get_opencode_client(conversation_id)
+    conversation = [
+        {"role": "system", "content": SYSTEM_PROMPT.format(semester=semester)},
+        *[dict(message) for message in messages],
+    ]
+    tool_calls = []
+    previews = {}
+    reply_parts = []
+    endpoint = f"{settings.OPENCODE_GO_BASE_URL.rstrip('/')}/chat/completions"
+
+    for _ in range(settings.CHAT_MAX_TOOL_TURNS):
+        wrote_this_pass = False
+        turn_parts = []
+        pending_calls = {}
+        finish_reason = None
+        try:
+            with client.post(
+                endpoint,
+                json={
+                    "model": model.api_model,
+                    "max_tokens": settings.CHAT_MAX_TOKENS,
+                    "stream": True,
+                    "messages": conversation,
+                    "tools": OPENAI_TOOLS,
+                },
+                stream=True,
+                timeout=(10, 300),
+            ) as response:
+                response.raise_for_status()
+                for line in response.iter_lines(decode_unicode=True):
+                    if not line or not line.startswith("data: "):
+                        continue
+                    data = line.removeprefix("data: ")
+                    if data == "[DONE]":
+                        break
+                    chunk = json.loads(data)
+                    choices = chunk.get("choices") or []
+                    if not choices:
+                        continue
+                    choice = choices[0]
+                    delta = choice.get("delta") or {}
+                    fragment = delta.get("content")
+                    if fragment:
+                        if reply_parts and not wrote_this_pass:
+                            reply_parts.append("\n\n")
+                            yield "text", "\n\n"
+                        wrote_this_pass = True
+                        reply_parts.append(fragment)
+                        turn_parts.append(fragment)
+                        yield "text", fragment
+                    for call in delta.get("tool_calls") or []:
+                        index = call.get("index", 0)
+                        pending = pending_calls.setdefault(
+                            index,
+                            {
+                                "id": None,
+                                "name": None,
+                                "arguments": "",
+                            },
+                        )
+                        pending["id"] = call.get("id") or pending["id"]
+                        function = call.get("function") or {}
+                        pending["name"] = function.get("name") or pending["name"]
+                        pending["arguments"] += function.get("arguments") or ""
+                    finish_reason = choice.get("finish_reason") or finish_reason
+        except requests.HTTPError as e:
+            logger.exception("OpenCode Go upstream error")
+            if e.response is not None and e.response.status_code == 429:
+                raise ChatUnavailable(
+                    "The assistant is handling too many requests right now. "
+                    "Try again in a moment."
+                )
+            raise ChatUnavailable("The assistant is temporarily unavailable.")
+        except (requests.RequestException, ValueError):
+            logger.exception("OpenCode Go connection or stream error")
+            raise ChatUnavailable("Could not reach the assistant. Check your connection.")
+
+        if not pending_calls:
+            if finish_reason == "content_filter":
+                raise ChatUnavailable("The assistant declined to answer that.")
+            yield "done", _completed_turn(
+                reply_parts,
+                tool_calls,
+                previews,
+                truncated=finish_reason == "length",
+            )
+            return
+
+        assistant_calls = []
+        for pending in pending_calls.values():
+            tool_use_id = pending["id"]
+            name = pending["name"]
+            arguments = pending["arguments"] or "{}"
+            if not tool_use_id or not name:
+                logger.warning("OpenCode Go returned an incomplete tool call")
+                raise ChatUnavailable("The assistant returned an incomplete lookup request.")
+            assistant_calls.append(
+                {
+                    "id": tool_use_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }
+            )
+
+        conversation.append(
+            {
+                "role": "assistant",
+                "content": "".join(turn_parts) or None,
+                "tool_calls": assistant_calls,
+            }
+        )
+        for pending in pending_calls.values():
+            tool_use_id = pending["id"]
+            name = pending["name"]
+            tool_input = {}
+            try:
+                tool_input = json.loads(pending["arguments"] or "{}")
+                if not isinstance(tool_input, dict):
+                    raise ToolError("Tool arguments must be a JSON object.")
+                value = run_tool(name, tool_input, semester=semester, user=user)
+                call = {"name": name, "input": tool_input, "ok": True}
+                tool_calls.append(call)
+                yield "tool_call", call
+                for preview in collect_previews(name, value):
+                    record = previews.setdefault(preview["course_code"], preview)
+                    record.update({key: item for key, item in preview.items() if item is not None})
+                content = json.dumps(value, default=str)
+            except (ToolError, ValueError, TypeError) as e:
+                call = {"name": name, "input": tool_input, "ok": False}
+                tool_calls.append(call)
+                yield "tool_call", call
+                content = json.dumps({"error": str(e)})
+            except Exception:
+                logger.exception("chat tool %s failed", name)
+                call = {"name": name, "input": tool_input, "ok": False}
+                tool_calls.append(call)
+                yield "tool_call", call
+                content = json.dumps({"error": "This lookup failed unexpectedly."})
+            conversation.append({"role": "tool", "tool_call_id": tool_use_id, "content": content})
+
+    logger.warning("chat hit the tool turn limit (semester=%s)", semester)
+    raise ChatUnavailable(
+        "That question took too many lookups to answer. Try asking something narrower."
+    )
+
+
+def run_chat_turn(messages, *, semester, user, client=None, model=None, conversation_id=None):
     """
     Run one turn and return it whole: `reply`, `tool_calls`, `courses`, `truncated`.
 
     A thin drain of `stream_chat_turn`, for callers that have nowhere to put partial
     output — the JSON endpoint, management commands, tests.
     """
-    for kind, payload in stream_chat_turn(messages, semester=semester, user=user, client=client):
+    for kind, payload in stream_chat_turn(
+        messages,
+        semester=semester,
+        user=user,
+        client=client,
+        model=model,
+        conversation_id=conversation_id,
+    ):
         if kind == "done":
             return payload
     # stream_chat_turn either yields "done" or raises; this is unreachable.

--- a/backend/chat/providers.py
+++ b/backend/chat/providers.py
@@ -1,0 +1,96 @@
+"""The server-owned catalog of chat models and their credentials."""
+
+from dataclasses import asdict, dataclass
+
+from django.conf import settings
+
+
+@dataclass(frozen=True)
+class ChatModel:
+    """One supported model, identified by the stable id exposed to clients."""
+
+    id: str
+    api_model: str
+    label: str
+    provider: str
+
+    def public(self):
+        """Return only metadata that is safe to send to a browser."""
+        return {key: value for key, value in asdict(self).items() if key != "api_model"}
+
+
+class ChatModelUnavailable(Exception):
+    """The requested model is not enabled by this server's configuration."""
+
+
+class ChatNotConfigured(Exception):
+    """No configured provider can serve chat requests."""
+
+
+def available_models():
+    """Return the curated models whose corresponding backend credentials exist."""
+    models = []
+    if settings.ANTHROPIC_API_KEY:
+        models.append(
+            ChatModel(
+                id=f"anthropic/{settings.CHAT_MODEL}",
+                api_model=settings.CHAT_MODEL,
+                label=settings.CHAT_MODEL.replace("-", " ").title(),
+                provider="Anthropic",
+            )
+        )
+    if settings.OPENCODE_GO_API_KEY:
+        models.extend(
+            [
+                ChatModel(
+                    id="opencode-go/deepseek-v4.1-flash",
+                    api_model="deepseek-v4.1-flash",
+                    label="DeepSeek V4.1 Flash",
+                    provider="OpenCode Go",
+                ),
+                ChatModel(
+                    id="opencode-go/glm-5.3",
+                    api_model="glm-5.3",
+                    label="GLM-5.3",
+                    provider="OpenCode Go",
+                ),
+            ]
+        )
+    return models
+
+
+def default_model(models=None):
+    """Choose the configured default, falling back predictably when it is unavailable."""
+    models = models if models is not None else available_models()
+    if not models:
+        raise ChatNotConfigured("The course chat assistant is not configured on this server.")
+
+    configured_id = settings.CHAT_DEFAULT_MODEL
+    for model in models:
+        if model.id == configured_id:
+            return model
+
+    # Keep the existing Anthropic deployment useful when OpenCode Go is absent.
+    return models[0]
+
+
+def resolve_model(model_id=None):
+    """Resolve a client model id without accepting arbitrary providers or endpoints."""
+    models = available_models()
+    if not models:
+        raise ChatNotConfigured("The course chat assistant is not configured on this server.")
+    if not model_id:
+        return default_model(models)
+    for model in models:
+        if model.id == model_id:
+            return model
+    raise ChatModelUnavailable("That chat model is not available on this server.")
+
+
+def model_catalog():
+    """The complete, key-gated catalog used by the frontend model selector."""
+    models = available_models()
+    return {
+        "default_model": default_model(models).id if models else None,
+        "models": [model.public() for model in models],
+    }

--- a/backend/chat/serializers.py
+++ b/backend/chat/serializers.py
@@ -25,6 +25,13 @@ class ChatRequestSerializer(serializers.Serializer):
         max_length=settings.CHAT_MAX_MESSAGES,
     )
     semester = serializers.CharField(required=False, allow_blank=True)
+    # The id is selected from the server-owned catalog in the view. Keeping this
+    # field opaque here prevents a client from smuggling an arbitrary provider URL
+    # or credential through the request body.
+    model = serializers.CharField(required=False, max_length=120)
+    # The backend remains stateless. The browser supplies an opaque id so OpenCode
+    # Go can maintain prompt-cache affinity for one visible conversation.
+    conversation_id = serializers.UUIDField(required=False)
 
     def validate_messages(self, messages):
         if messages[0]["role"] != "user":

--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from chat.views import ChatStreamView, ChatView
+from chat.views import ChatModelsView, ChatStreamView, ChatView
 
 
 urlpatterns = [
+    path("models/", ChatModelsView.as_view(), name="chat-models"),
     path("", ChatView.as_view(), name="chat"),
     path("stream/", ChatStreamView.as_view(), name="chat-stream"),
 ]

--- a/backend/chat/views.py
+++ b/backend/chat/views.py
@@ -10,11 +10,35 @@ from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from chat.agent import ChatUnavailable, run_chat_turn, stream_chat_turn
+from chat.providers import ChatModelUnavailable, ChatNotConfigured, model_catalog, resolve_model
 from chat.serializers import ChatRequestSerializer
 from PennCourses.docs_settings import PcxAutoSchema
 
 
 logger = logging.getLogger(__name__)
+
+
+class ChatModelsView(APIView):
+    """The server-configured models that a signed-in student may select."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        del request
+        return Response(model_catalog())
+
+
+def _resolved_model(serializer):
+    """Resolve the optional request model into a key-gated server model."""
+    return resolve_model(serializer.validated_data.get("model"))
+
+
+def _conversation_id(serializer, request):
+    """Get a stable session id without adding server-side chat state."""
+    value = serializer.validated_data.get("conversation_id")
+    if value is not None:
+        return str(value)
+    return request.session.session_key or f"pcx-user-{request.user.pk}"
 
 
 class ChatView(APIView):
@@ -61,6 +85,21 @@ class ChatView(APIView):
                                 "(e.g. 2024C). Defaults to the current semester."
                             ),
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "An id returned by GET /api/chat/models/. Defaults to "
+                                "the server's configured chat model."
+                            ),
+                        },
+                        "conversation_id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": (
+                                "An opaque browser-generated id that stays stable for "
+                                "one visible conversation."
+                            ),
+                        },
                     },
                 }
             }
@@ -78,6 +117,12 @@ class ChatView(APIView):
                             "semester": {
                                 "type": "string",
                                 "description": "The semester the reply was scoped to.",
+                            },
+                            "model": {
+                                "type": "string",
+                                "description": (
+                                    "The server-validated model that generated the reply."
+                                ),
                             },
                             "tool_calls": {
                                 "type": "array",
@@ -149,17 +194,25 @@ class ChatView(APIView):
         serializer.is_valid(raise_exception=True)
 
         semester = serializer.validated_semester()
+        try:
+            model = _resolved_model(serializer)
+        except ChatModelUnavailable as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ChatNotConfigured as e:
+            return Response({"detail": str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
         try:
             result = run_chat_turn(
                 serializer.validated_data["messages"],
                 semester=semester,
                 user=request.user,
+                model=model,
+                conversation_id=_conversation_id(serializer, request),
             )
         except ChatUnavailable as e:
             return Response({"detail": str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
-        return Response({"semester": semester, **result})
+        return Response({"semester": semester, "model": model.id, **result})
 
 
 def _sse(event, payload):
@@ -210,12 +263,25 @@ class ChatStreamView(APIView):
         semester = serializer.validated_semester()
         messages = serializer.validated_data["messages"]
         user = request.user
+        try:
+            model = _resolved_model(serializer)
+        except ChatModelUnavailable as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except ChatNotConfigured as e:
+            return Response({"detail": str(e)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        conversation_id = _conversation_id(serializer, request)
 
         def events():
             try:
-                for kind, payload in stream_chat_turn(messages, semester=semester, user=user):
+                for kind, payload in stream_chat_turn(
+                    messages,
+                    semester=semester,
+                    user=user,
+                    model=model,
+                    conversation_id=conversation_id,
+                ):
                     if kind == "done":
-                        payload = {"semester": semester, **payload}
+                        payload = {"semester": semester, "model": model.id, **payload}
                     yield _sse(kind, payload)
             except ChatUnavailable as e:
                 yield _sse("error", {"detail": str(e)})

--- a/backend/degree/models.py
+++ b/backend/degree/models.py
@@ -293,7 +293,7 @@ class Rule(models.Model):
         return json_parser.parse(self.q)
 
 
-class DegreePlan(models.Model): 
+class DegreePlan(models.Model):
     """
     Stores a users plan for an associated degree.
     """

--- a/backend/tests/chat/test_chat.py
+++ b/backend/tests/chat/test_chat.py
@@ -5,7 +5,7 @@ import anthropic
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db.models.signals import post_save
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from options.models import Option
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -643,6 +643,7 @@ class ChatStreamingTestCase(TestCase):
         self.assertEqual(streamed, whole)
 
 
+@override_settings(ANTHROPIC_API_KEY="test-anthropic-key", OPENCODE_GO_API_KEY="")
 class ChatStreamViewTestCase(TestCase):
     def setUp(self):
         cache.clear()
@@ -750,6 +751,7 @@ class ChatStreamViewTestCase(TestCase):
         self.assertNotIn("boom", frames[-1][1]["detail"])
 
 
+@override_settings(ANTHROPIC_API_KEY="test-anthropic-key", OPENCODE_GO_API_KEY="")
 class ChatViewTestCase(TestCase):
     def setUp(self):
         cache.clear()
@@ -769,6 +771,14 @@ class ChatViewTestCase(TestCase):
         response = self.post({"messages": [{"role": "user", "content": "hi"}]})
         self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
 
+    def test_model_catalog_is_key_gated(self):
+        response = self.client.get("/api/chat/models/")
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(
+            ["anthropic/claude-sonnet-5"],
+            [model["id"] for model in response.json()["models"]],
+        )
+
     @patch("chat.views.run_chat_turn")
     def test_happy_path(self, mock_run):
         mock_run.return_value = {"reply": "Hello!", "tool_calls": [], "truncated": False}
@@ -777,6 +787,7 @@ class ChatViewTestCase(TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("Hello!", response.json()["reply"])
         self.assertEqual(TEST_SEMESTER, response.json()["semester"])
+        self.assertEqual("anthropic/claude-sonnet-5", response.json()["model"])
         self.assertEqual(TEST_SEMESTER, mock_run.call_args.kwargs["semester"])
 
     @patch("chat.views.run_chat_turn")

--- a/backend/tests/chat/test_providers.py
+++ b/backend/tests/chat/test_providers.py
@@ -1,0 +1,166 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from chat.agent import get_opencode_client, run_chat_turn
+from chat.providers import ChatModel, model_catalog
+from tests.chat.test_chat import TEST_SEMESTER, set_semester
+from tests.courses.util import create_mock_data_with_reviews
+
+
+User = get_user_model()
+
+OPENCODE_MODEL = ChatModel(
+    id="opencode-go/deepseek-v4.1-flash",
+    api_model="deepseek-v4.1-flash",
+    label="DeepSeek V4.1 Flash",
+    provider="OpenCode Go",
+)
+
+
+class ScriptedOpenCodeResponse:
+    """A minimal server-sent-event response stand-in for the Go adapter."""
+
+    def __init__(self, chunks):
+        self.chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self, decode_unicode=False):
+        del decode_unicode
+        for chunk in self.chunks:
+            yield chunk if isinstance(chunk, str) else "data: " + json.dumps(chunk)
+
+
+class ScriptedOpenCodeClient:
+    """Records OpenAI-compatible requests and returns scripted SSE responses."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError("ScriptedOpenCodeClient ran out of queued responses")
+        return ScriptedOpenCodeResponse(self.responses.pop(0))
+
+
+class OpenCodeGoChatTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        set_semester()
+        create_mock_data_with_reviews("CIS-120-001", TEST_SEMESTER, 2)
+        self.user = User.objects.create_user(username="opencode", password="secret")
+
+    def test_streams_text_with_openai_compatible_request(self):
+        client = ScriptedOpenCodeClient(
+            [
+                [
+                    {"choices": [{"delta": {"content": "Hello"}, "finish_reason": None}]},
+                    {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+                    "data: [DONE]",
+                ]
+            ]
+        )
+
+        result = run_chat_turn(
+            [{"role": "user", "content": "hello"}],
+            semester=TEST_SEMESTER,
+            user=self.user,
+            client=client,
+            model=OPENCODE_MODEL,
+            conversation_id="session-1",
+        )
+
+        self.assertEqual("Hello", result["reply"])
+        self.assertEqual("deepseek-v4.1-flash", client.calls[0]["json"]["model"])
+        self.assertEqual("system", client.calls[0]["json"]["messages"][0]["role"])
+        self.assertEqual("function", client.calls[0]["json"]["tools"][0]["type"])
+
+    def test_runs_and_returns_openai_compatible_tool_calls(self):
+        client = ScriptedOpenCodeClient(
+            [
+                [
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_1",
+                                            "function": {
+                                                "name": "get_course",
+                                                "arguments": '{"course_code":"CIS-',
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [{"index": 0, "function": {"arguments": '120"}'}}]
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ]
+                    },
+                    "data: [DONE]",
+                ],
+                [
+                    {
+                        "choices": [
+                            {"delta": {"content": "CIS-120 is available."}, "finish_reason": None}
+                        ]
+                    },
+                    {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+                    "data: [DONE]",
+                ],
+            ]
+        )
+
+        result = run_chat_turn(
+            [{"role": "user", "content": "Tell me about CIS-120"}],
+            semester=TEST_SEMESTER,
+            user=self.user,
+            client=client,
+            model=OPENCODE_MODEL,
+            conversation_id="session-2",
+        )
+
+        self.assertEqual(["get_course"], [call["name"] for call in result["tool_calls"]])
+        tool_message = client.calls[1]["json"]["messages"][-1]
+        self.assertEqual("tool", tool_message["role"])
+        self.assertEqual("call_1", tool_message["tool_call_id"])
+
+
+class ChatProviderCatalogTestCase(TestCase):
+    @override_settings(ANTHROPIC_API_KEY="anthropic-key", OPENCODE_GO_API_KEY="go-key")
+    def test_catalog_only_exposes_key_enabled_models_and_prefers_deepseek(self):
+        catalog = model_catalog()
+        self.assertEqual("opencode-go/deepseek-v4.1-flash", catalog["default_model"])
+        self.assertEqual(
+            ["anthropic/claude-sonnet-5", "opencode-go/deepseek-v4.1-flash", "opencode-go/glm-5.3"],
+            [model["id"] for model in catalog["models"]],
+        )
+
+    @override_settings(ANTHROPIC_API_KEY="", OPENCODE_GO_API_KEY="go-key")
+    def test_opencode_client_sends_provider_session_headers(self):
+        client = get_opencode_client("visible-conversation")
+        self.assertEqual("Bearer go-key", client.headers["Authorization"])
+        self.assertEqual("visible-conversation", client.headers["x-opencode-session"])

--- a/frontend/chat/README.md
+++ b/frontend/chat/README.md
@@ -20,9 +20,10 @@ finishes.
 
 ## Running it
 
-The backend has to be running on port 8000, with an Anthropic API key in its
-environment (see `backend/README.md` — note that nothing loads `.env`
-automatically):
+The backend has to be running on port 8000, with at least one supported provider key
+in its environment: `ANTHROPIC_API_KEY` for Claude or `OPENCODE_GO_API_KEY` for the
+curated DeepSeek V4.1 Flash and GLM-5.3 choices (see `backend/README.md` — note that
+nothing loads `.env` automatically):
 
 ```bash
 cd backend

--- a/frontend/chat/components/Chat.tsx
+++ b/frontend/chat/components/Chat.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 
+import { ChatModel, fetchChatModels } from "../lib/api";
 import { useChat } from "../lib/useChat";
 import Message from "./Message";
 import { theme } from "./theme";
@@ -56,6 +57,21 @@ const TextButton = styled.button`
     }
 `;
 
+const ModelSelect = styled.select`
+    max-width: 13rem;
+    border: 1px solid ${theme.border};
+    border-radius: 6px;
+    padding: 0.25rem 1.7rem 0.25rem 0.45rem;
+    color: ${theme.text};
+    background-color: ${theme.surface};
+    font: inherit;
+    font-size: 0.8rem;
+
+    &:disabled {
+        color: ${theme.textMuted};
+    }
+`;
+
 const Scroller = styled.div`
     flex: 1;
     overflow-y: auto;
@@ -107,6 +123,11 @@ const Suggestion = styled.button`
     &:hover {
         border-color: ${theme.accent};
         background-color: ${theme.accentWash};
+    }
+
+    &:disabled {
+        color: ${theme.textMuted};
+        cursor: default;
     }
 `;
 
@@ -192,11 +213,29 @@ const Disclaimer = styled.p`
     text-align: center;
 `;
 
+const CatalogNotice = styled.p`
+    margin: 1rem 0 0;
+    color: ${theme.danger};
+    font-size: 0.85rem;
+`;
+
 const SUGGESTIONS = [
     "What are some highly rated CIS electives?",
     "Is CIS-1200 hard? Who should I take it with?",
     "What's in my cart, and does it have any conflicts?",
 ];
+
+const createConversationId = (): string => {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+    // All supported production browsers have randomUUID; this preserves a stable
+    // opaque id for older ones without putting any user data in the value.
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+        const value = Math.floor(Math.random() * 16);
+        return (char === "x" ? value : (value & 0x3) | 0x8).toString(16);
+    });
+};
 
 const Chat = ({ username }: { username: string }) => {
     const {
@@ -211,7 +250,43 @@ const Chat = ({ username }: { username: string }) => {
         dismissError,
     } = useChat();
     const [draft, setDraft] = useState("");
+    const [models, setModels] = useState<ChatModel[]>([]);
+    const [selectedModel, setSelectedModel] = useState<string | null>(null);
+    const [loadingModels, setLoadingModels] = useState(true);
+    const [modelsError, setModelsError] = useState<string | null>(null);
     const bottomRef = useRef<HTMLDivElement>(null);
+    const conversationId = useRef(createConversationId());
+
+    useEffect(() => {
+        let active = true;
+        fetchChatModels()
+            .then((catalog) => {
+                if (!active) return;
+                setModels(catalog.models);
+                setSelectedModel(
+                    catalog.default_model || catalog.models[0]?.id || null
+                );
+                if (!catalog.models.length) {
+                    setModelsError(
+                        "No chat model is configured on this server."
+                    );
+                }
+            })
+            .catch((e) => {
+                if (!active) return;
+                setModelsError(
+                    e instanceof Error
+                        ? e.message
+                        : "Could not load the available chat models."
+                );
+            })
+            .finally(() => {
+                if (active) setLoadingModels(false);
+            });
+        return () => {
+            active = false;
+        };
+    }, []);
 
     useEffect(() => {
         if (bottomRef.current) {
@@ -221,9 +296,20 @@ const Chat = ({ username }: { username: string }) => {
 
     const submit = (event?: React.FormEvent) => {
         if (event) event.preventDefault();
-        if (!draft.trim() || pending) return;
-        send(draft);
+        if (!draft.trim() || pending || !selectedModel) return;
+        send(draft, selectedModel, conversationId.current);
         setDraft("");
+    };
+
+    const newChat = () => {
+        clear();
+        conversationId.current = createConversationId();
+    };
+
+    const changeModel = (model: string) => {
+        if (!model || model === selectedModel) return;
+        setSelectedModel(model);
+        newChat();
     };
 
     const isEmpty = turns.length === 0 && !pending && !failed;
@@ -235,10 +321,26 @@ const Chat = ({ username }: { username: string }) => {
                     Penn Course <span>Chat</span>
                 </Wordmark>
                 <BarRight>
+                    <ModelSelect
+                        aria-label="Chat model"
+                        value={selectedModel || ""}
+                        disabled={loadingModels || !!pending || !models.length}
+                        onChange={(event) => changeModel(event.target.value)}
+                    >
+                        {loadingModels ? (
+                            <option value="">Loading models…</option>
+                        ) : (
+                            models.map((model) => (
+                                <option key={model.id} value={model.id}>
+                                    {model.provider}: {model.label}
+                                </option>
+                            ))
+                        )}
+                    </ModelSelect>
                     {semester && <span>{semester}</span>}
                     <TextButton
                         type="button"
-                        onClick={clear}
+                        onClick={newChat}
                         disabled={isEmpty || !!pending}
                     >
                         New chat
@@ -261,12 +363,25 @@ const Chat = ({ username }: { username: string }) => {
                                     <Suggestion
                                         key={suggestion}
                                         type="button"
-                                        onClick={() => send(suggestion)}
+                                        disabled={
+                                            !selectedModel || loadingModels
+                                        }
+                                        onClick={() =>
+                                            selectedModel &&
+                                            send(
+                                                suggestion,
+                                                selectedModel,
+                                                conversationId.current
+                                            )
+                                        }
                                     >
                                         {suggestion}
                                     </Suggestion>
                                 ))}
                             </Suggestions>
+                            {modelsError && (
+                                <CatalogNotice>{modelsError}</CatalogNotice>
+                            )}
                         </Splash>
                     ) : (
                         <>
@@ -318,7 +433,17 @@ const Chat = ({ username }: { username: string }) => {
                 <ErrorBar>
                     <span>{error}</span>
                     {failed ? (
-                        <ErrorAction type="button" onClick={() => send(failed)}>
+                        <ErrorAction
+                            type="button"
+                            onClick={() =>
+                                selectedModel &&
+                                send(
+                                    failed,
+                                    selectedModel,
+                                    conversationId.current
+                                )
+                            }
+                        >
                             Retry
                         </ErrorAction>
                     ) : (
@@ -343,7 +468,15 @@ const Chat = ({ username }: { username: string }) => {
                             }
                         }}
                     />
-                    <Send type="submit" disabled={!draft.trim() || !!pending}>
+                    <Send
+                        type="submit"
+                        disabled={
+                            !draft.trim() ||
+                            !!pending ||
+                            !selectedModel ||
+                            loadingModels
+                        }
+                    >
                         Send
                     </Send>
                 </Composer>

--- a/frontend/chat/lib/api.ts
+++ b/frontend/chat/lib/api.ts
@@ -33,9 +33,21 @@ export interface ChatTurn {
 export interface ChatReply {
     reply: string;
     semester: string;
+    model: string;
     tool_calls: ToolCall[];
     courses: CoursePreview[];
     truncated: boolean;
+}
+
+export interface ChatModel {
+    id: string;
+    label: string;
+    provider: string;
+}
+
+export interface ChatModelCatalog {
+    default_model: string | null;
+    models: ChatModel[];
 }
 
 export interface User {
@@ -68,6 +80,22 @@ export class ApiError extends Error {
     }
 }
 
+const messageBody = (
+    history: ChatTurn[],
+    content: string,
+    model: string,
+    conversationId: string,
+    semester?: string
+) => ({
+    messages: [
+        ...history.map(({ role, content: text }) => ({ role, content: text })),
+        { role: "user", content },
+    ],
+    model,
+    conversation_id: conversationId,
+    ...(semester ? { semester } : {}),
+});
+
 /** Returns the logged-in user, or null if this browser has no session. */
 export const fetchUser = async (): Promise<User | null> => {
     const response = await fetch("/accounts/me/", {
@@ -76,6 +104,22 @@ export const fetchUser = async (): Promise<User | null> => {
     });
     if (!response.ok) return null;
     return response.json();
+};
+
+/** Return only the models this server can authenticate to right now. */
+export const fetchChatModels = async (): Promise<ChatModelCatalog> => {
+    const response = await fetch("/api/chat/models/", {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+    });
+    const body = await response.json().catch(() => ({} as any));
+    if (!response.ok) {
+        throw new ApiError(
+            body.detail || "Could not load the available chat models.",
+            response.status
+        );
+    }
+    return body as ChatModelCatalog;
 };
 
 /**
@@ -87,6 +131,8 @@ export const fetchUser = async (): Promise<User | null> => {
 export const sendMessage = async (
     history: ChatTurn[],
     content: string,
+    model: string,
+    conversationId: string,
     semester?: string
 ): Promise<ChatReply> => {
     const response = await fetch("/api/chat/", {
@@ -98,16 +144,9 @@ export const sendMessage = async (
             "Content-Type": "application/json",
             "X-CSRFToken": getCsrf(),
         },
-        body: JSON.stringify({
-            messages: [
-                ...history.map(({ role, content: text }) => ({
-                    role,
-                    content: text,
-                })),
-                { role: "user", content },
-            ],
-            ...(semester ? { semester } : {}),
-        }),
+        body: JSON.stringify(
+            messageBody(history, content, model, conversationId, semester)
+        ),
     });
 
     const body = await response.json().catch(() => ({} as any));
@@ -152,6 +191,8 @@ export interface StreamHandlers {
 export const streamMessage = async (
     history: ChatTurn[],
     content: string,
+    model: string,
+    conversationId: string,
     handlers: StreamHandlers
 ): Promise<ChatReply> => {
     const response = await fetch("/api/chat/stream/", {
@@ -163,15 +204,9 @@ export const streamMessage = async (
             "Content-Type": "application/json",
             "X-CSRFToken": getCsrf(),
         },
-        body: JSON.stringify({
-            messages: [
-                ...history.map(({ role, content: text }) => ({
-                    role,
-                    content: text,
-                })),
-                { role: "user", content },
-            ],
-        }),
+        body: JSON.stringify(
+            messageBody(history, content, model, conversationId)
+        ),
     });
 
     if (!response.ok) {

--- a/frontend/chat/lib/useChat.ts
+++ b/frontend/chat/lib/useChat.ts
@@ -124,16 +124,24 @@ export const useChat = () => {
     const [state, dispatch] = useReducer(reducer, initialState);
 
     const send = useCallback(
-        async (raw: string) => {
+        async (raw: string, model: string, conversationId: string) => {
             const content = raw.trim();
-            if (!content || state.pending) return;
+            if (!content || !model || !conversationId || state.pending) return;
 
             dispatch({ type: "sent", content });
             try {
-                const reply = await streamMessage(state.turns, content, {
-                    onText: (fragment) => dispatch({ type: "text", fragment }),
-                    onToolCall: (call) => dispatch({ type: "toolCall", call }),
-                });
+                const reply = await streamMessage(
+                    state.turns,
+                    content,
+                    model,
+                    conversationId,
+                    {
+                        onText: (fragment) =>
+                            dispatch({ type: "text", fragment }),
+                        onToolCall: (call) =>
+                            dispatch({ type: "toolCall", call }),
+                    }
+                );
                 dispatch({
                     type: "replied",
                     content,


### PR DESCRIPTION
## Summary
- Add selectable Anthropic and OpenCode Go chat models
- Provide a backend model catalog driven by configured API keys
- Start a new local chat when changing models

## Testing
- yarn workspace penncoursechat lint
- uv run manage.py test tests.chat (121 passed)